### PR TITLE
Export public key to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,7 +787,7 @@ Type `key 1` again to deselect and `key 2` to switch to the next key.
 
 ## Export public key
 
-    $ gpg --armor --export $KEYID > /mnt/public-usb-key/
+    $ gpg --armor --export $KEYID > /mnt/public-usb-key/pubkey.asc
 
 # Using keys
 


### PR DESCRIPTION
The public key must be written on a file.