### PR TITLE
Use AES256 for private key password encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Paste the following [text](https://stackoverflow.com/questions/2500436/how-does-
     default-preference-list SHA512 SHA384 SHA256 SHA224 AES256 AES192 AES CAST5 ZLIB BZIP2 ZIP Uncompressed
     cert-digest-algo SHA512
     s2k-digest-algo SHA512
+    s2k-cipher-algo AES256
     charset utf-8
     fixed-list-mode
     no-comments
@@ -939,6 +940,7 @@ Paste the following text into a terminal window to create a [recommended](https:
     personal-digest-preferences SHA512 SHA384 SHA256 SHA224
     default-preference-list SHA512 SHA384 SHA256 SHA224 AES256 AES192 AES CAST5 ZLIB BZIP2 ZIP Uncompressed
     cert-digest-algo SHA512
+    s2k-cipher-algo AES256
     s2k-digest-algo SHA512
     charset utf-8
     fixed-list-mode


### PR DESCRIPTION
Adds 

```
s2k-cipher-algo AES256
```

to the GPG configuration, per https://pthree.org/2015/11/19/your-gnupg-private-key/

> --s2k-cipher-algo name
> Use name as the cipher algorithm used to protect secret keys. The default cipher is CAST5. This cipher is also used for symmetric encryption with a passphrase if --personal-cipher-preferences and --cipher-algo is not given.

https://www.gnupg.org/documentation/manuals/gnupg-2.0/OpenPGP-Options.html#index-s2k_002dcipher_002dalgo