### PR TITLE
Replace hkt with gpg to fix unsupported GnuPG 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ Use the automated [key best practice checker](https://riseup.net/en/security/mes
 
 ```
 $ sudo apt-get install hopenpgp-tools
-$ hkt export-pubkeys $KEYID --keyring=$GNUPGHOME/pubring.gpg | hokey lint
+$ gpg --export $KEYID | hokey lint
 ```
 
 The output will display any problems with your key in red text. If everything is green, your key passes each of the tests below. If it is red, your key has failed one of the tests.


### PR DESCRIPTION
hkt does not support GnuPG 2.1 because it expects gpg pubring.

But the export can be done by gpg itself.