### PR TITLE
Fix ssh-agent does not work on archlinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1165,9 +1165,10 @@ Depending on how your environment is set up, you might need to add these to your
     export SSH_AUTH_SOCK="${HOME}/.gnupg/S.gpg-agent.ssh"
     gpgconf --launch gpg-agent
     
-**Note : ** On some systems, for example Archlinux based distros, you need to replace the second line by 
+**Note : ** On some systems, for example Archlinux based distros, you need to replace the second and the third line by 
 ```
 export SSH_AUTH_SOCK="/run/user/$UID/gnupg/S.gpg-agent.ssh"
+gpg-connect-agent updatestartuptty /bye
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1164,6 +1164,11 @@ Depending on how your environment is set up, you might need to add these to your
     export GPG_TTY="$(tty)"
     export SSH_AUTH_SOCK="${HOME}/.gnupg/S.gpg-agent.ssh"
     gpgconf --launch gpg-agent
+    
+**Note : ** On some systems, for example Archlinux based distros, you need to replace the second line by 
+```
+export SSH_AUTH_SOCK="/run/user/$UID/gnupg/S.gpg-agent.ssh"
+```
 
 
 ### Copy public key to server


### PR DESCRIPTION
On all my archlinux computers, the ssh-agent does not work. I had to set SSH_AUTH_SOCK to `/run/user/$UID/gnupg/S.gpg-agent.ssh` to make it working. 