### PR TITLE
remove outdated use-standard-socket option from SSH config, see here:…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,7 +1147,6 @@ Paste the following text into a terminal window to create a [recommended](https:
     default-cache-ttl 60
     max-cache-ttl 120
     write-env-file
-    use-standard-socket
     EOF
 
 If you are using Linux on the desktop, you may want to use `/usr/bin/pinentry-gnome3` to use a GUI manager. For macOS, try `brew install pinentry-mac`, and adjust the `pinentry-program` setting to suit.


### PR DESCRIPTION
… https://www.gnupg.org/documentation/manuals/gnupg/Agent-Options.html