### PR TITLE
Install hopenpgp-tools with brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If on [Tails](https://tails.boum.org/), you also need to install libykpers-1-1 f
 
 You will need to install [Homebrew](https://brew.sh/) and the following brew packages:
 
-    $ brew install gnupg yubikey-personalization
+    $ brew install gnupg yubikey-personalization hopenpgp-tools
 
 # Creating keys
 


### PR DESCRIPTION
Under section https://github.com/drduh/YubiKey-Guide#check-your-work there is an `apt-get` command to install `hopenpgp-tools`:

```
sudo apt-get install hopenpgp-tools
```

We should probably install this alongside the other tools for macOS using brew.

Otherwise, maybe we should update the section `#check-your-work` to give both a command for linux and macOS.