### PR TITLE
Fix live image integrity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ curl -LfO https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/S
 
 $ !!.sign
 
-$ gpg SHA512SUMS.sign
+$ gpg --verify SHA512SUMS.sign SHA512SUMS
 [...]
 gpg: Good signature from "Debian CD signing key <debian-cd@lists.debian.org>" [unknown]
 [...]


### PR DESCRIPTION
`gpg SHA512SUMS.sign` would do the right thing only if the file actually contained a detached signature.

Use explicit and robust `gpg --verify SHA512SUMS.sign SHA512SUMS` instead.