### PR TITLE
Add packages to apt-get list to fix gpg --recv and srm commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ $ sudo apt-get update
 $ sudo apt-get install -y \
      curl gnupg2 gnupg-agent \
      cryptsetup scdaemon pcscd \
-     yubikey-personalization
+     yubikey-personalization \
+     dirmngr \
+     secure-delete
 ```
 
 You may also need more recent versions of [yubikey-personalization](https://developers.yubico.com/yubikey-personalization/Releases/) and [yubico-c](https://developers.yubico.com/yubico-c/Releases/).


### PR DESCRIPTION
Two commands mentioned later in the document won't work without two packages that don't come pre-installed with the Debian LiveCD:  dirmngr and secure-delete.