### PR TITLE
remove broken gpg option (debian 9.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ keyid-format 0xlong
 list-options show-uid-validity
 verify-options show-uid-validity
 with-fingerprint
-with-key-origin
 require-cross-certification
 no-symkey-cache
 throw-keyids


### PR DESCRIPTION
As per [0], the --with-key-origin option is experimental.

0: https://www.gnupg.org/documentation/manuals/gnupg/GPG-Input-and-Output.html#index-with_002dkey_002dorigin