### PR TITLE
Add addition note about red hokey output

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,8 @@ $ gpg --export $KEYID | hokey lint
 
 The output will display any problems with your key in red text. If everything is green, your key passes each of the tests. If it is red, your key has failed one of the tests.
 
-> hokey may warn (orange text) about cross certification for the authentication key. GPG's [Signing Subkey Cross-Certification](https://gnupg.org/faq/subkey-cross-certify.html) documentation has more detail on cross certification, and gpg v2.2.1 notes "subkey <keyid> does not sign and so does not need to be cross-certified".
+> hokey may warn (orange text) about cross certification for the authentication key. GPG's [Signing Subkey Cross-Certification](https://gnupg.org/faq/subkey-cross-certify.html) documentation has more detail on cross certification, and gpg v2.2.1 notes "subkey <keyid> does not sign and so does not need to be cross-certified". hokey may also indicate a problem (red text) with `Key expiration times: []` on the primary key (see [Note #3](#notes) about not setting an expiry for the primary key).
+
 
 # Export keys
 


### PR DESCRIPTION
I noticed there was an explanation for the warning of orange text, but not for red output that may show up if someone choosing to ignore this guides recommendation to not set an expiry for the red text. Putting this explicitly in the guide saves the reader the time of double-checking that this output has to do with the choice of not putting an expiring in place.