### PR TITLE
Fix 'Require Touch' ykman syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1838,19 +1838,19 @@ To require a touch for each key operation, install [YubiKey Manager](https://dev
 Authentication:
 
 ```console
-$ ykman openpgp touch aut on
+$ ykman openpgp set-touch aut on
 ```
 
 Signing:
 
 ```console
-$ ykman openpgp touch sig on
+$ ykman openpgp set-touch sig on
 ```
 
 Encryption:
 
 ```console
-$ ykman openpgp touch enc on
+$ ykman openpgp set-touch enc on
 ```
 
 YubiKey will blink when it is waiting for a touch.


### PR DESCRIPTION
The syntax to change Yubikey touch configurations with ykman has changed. Updating this accordingly.

Relevant upstream change: https://github.com/Yubico/yubikey-manager/commit/7b54512a05dbb31a332babd622b8445a1f543daf#diff-017758723c502ad32603406c828aa10c