### PR TITLE
Leave a note that `set-touch` used to be `touch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1837,6 +1837,8 @@ By default, YubiKey will perform encryption, signing and authentication operatio
 
 To require a touch for each key operation, install [YubiKey Manager](https://developers.yubico.com/yubikey-manager/) and recall the Admin PIN:
 
+**Note** Older versions of the YubiKey Manager used `touch` instead of `set-touch` in the below commands.
+
 Authentication:
 
 ```console


### PR DESCRIPTION
Recently a PR was merged that edited the [Require Touch](https://github.com/drduh/YubiKey-Guide#require-touch) section to update the command syntax for newer versions of `ykman`.

However, versions of `ykman` that are still being distributed widely (such as Debian's) are still too old to have `set-touch`, and still use the old `touch` syntax.

This PR adds a note so that individuals with the old versions don't have to go on a searching spree to find the right command syntax.