### PR TITLE
Move Output Option to Earlier in Export Command for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,9 +666,9 @@ $ gpg --armor --export-secret-subkeys $KEYID > $GNUPGHOME/sub.key
 On Windows, note that using any extension other than `.gpg` or attempting IO redirection to a file will garble the secret key, making it impossible to import it again at a later date:
 
 ```console
-$ gpg --armor --export-secret-keys $KEYID -o \path\to\dir\mastersub.gpg
+$ gpg -o \path\to\dir\mastersub.gpg --armor --export-secret-keys $KEYID
 
-$ gpg --armor --export-secret-subkeys $KEYID -o \path\to\dir\sub.gpg
+$ gpg -o \path\to\dir\sub.gpg --armor --export-secret-subkeys $KEYID
 ```
 
 # Backup
@@ -841,7 +841,7 @@ $ gpg --armor --export $KEYID | sudo tee /mnt/public/$KEYID-$(date +%F).txt
 Windows:
 
 ```console
-$ gpg --armor --export $KEYID -o \path\to\dir\pubkey.gpg
+$ gpg -o \path\to\dir\pubkey.gpg --armor --export $KEYID
 ```
 
 **Optional** Upload the public key to a [public keyserver](https://debian-administration.org/article/451/Submitting_your_GPG_key_to_a_keyserver):


### PR DESCRIPTION
When exporting keys, using `-o` at the end will only output to the console and not the file. Using `--output` instead of `-o` says `gpg: Note: '--output' is not considered an option`. Moving `-o`/`--output` to before `--export` command seems to solve this problem.

![Example](https://user-images.githubusercontent.com/2396432/62658832-57412780-b92f-11e9-8abb-65ebe02d6c53.png)

Tested with:
gpg (GnuPG) 2.2.11 and 2.2.17
PowerShell 5.1.18362.145
Windows 10 1903 18362.267

Possibly related to #67 