### PR TITLE
Redirect gpg-connect-agent ouput to /dev/null when added to shell `rc` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1502,7 +1502,7 @@ Add these to the shell `rc` file:
 ```console
 export GPG_TTY="$(tty)"
 export SSH_AUTH_SOCK="/run/user/$UID/gnupg/S.gpg-agent.ssh"
-gpg-connect-agent updatestartuptty /bye
+gpg-connect-agent updatestartuptty /bye > /dev/null
 ```
 
 On some systems, you may need to use the following instead:


### PR DESCRIPTION
When adding GPG SSH agent configuration to shell rc file, redirect output of gpg-connect-agent to /dev/null so that it doesn't output `OK` every time you bring up a new shell