### PR TITLE
Added a fix for failing ssh / GUI pinentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1580,7 +1580,7 @@ pinentry-program /usr/bin/pinentry-curses
 
 **Important** The `cache-ttl` options do **NOT** apply when using a YubiKey as a smartcard as the PIN is [cached by the smartcard itself](https://dev.gnupg.org/T3362). Therefore, in order to clear the PIN from cache (smartcard equivalent to `default-cache-ttl` and `max-cache-ttl`), you need to unplug the YubiKey.
 
-**Tip** Set `pinentry-program /usr/bin/pinentry-gnome3` for a GUI-based prompt.
+**Tip** Set `pinentry-program /usr/bin/pinentry-gnome3` for a GUI-based prompt. If the _pinentry_ graphical dialog doesn't show and you get this error: `sign_and_send_pubkey: signing failed: agent refused operation`, you probably need to install the `dbus-user-session` package and might have to restart the computer for the `dbus` user session to be fully inherited; this is because behind the scenes, `pinentry` complains about `No $DBUS_SESSION_BUS_ADDRESS found`, falls back to `curses` but doesn't find the expected `tty`.
 
 On macOS, use `brew install pinentry-mac` and adjust the program path to suit.
 


### PR DESCRIPTION
I've been hit by this for hours until I `strace`'d `pinentry` only to find out it was expecting a `$DBUS_SESSION_BUS_ADDRESS` variable.