### PR TITLE
Update GitHub instructions on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1772,9 +1772,10 @@ To authenticate:
 
 **Windows**
 
-Run the following command:
+Run the following commands:
 
 	> git config --global core.sshcommand 'plink -agent'
+	> git config --global gpg.program 'C:\Program Files (x86)\GnuPG\bin\gpg.exe'
 
 You can then change the repository url to `git@github.com:USERNAME/repository` and any authenticated commands will be authorized by YubiKey.
 


### PR DESCRIPTION
Add command to instruct Git to use WinGPG. By default, Git ships its own older copy of gpg, and it will fail to authenticate with the gpg keyring setup using WinGPG unless we tell it to use the new one.