### PR TITLE
Fix gnupg package name for Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ $ sudo apt install -y wget gnupg2 gnupg-agent dirmngr cryptsetup scdaemon pcscd 
 ## Arch
 
 ```console
-$ sudo pacman -Syu gnupg2 pcsclite ccid hopenpgp-tools yubikey-personalization
+$ sudo pacman -Syu gnupg pcsclite ccid hopenpgp-tools yubikey-personalization
 ```
 
 ## RHEL7


### PR DESCRIPTION
`gnupg2` has been [removed since March 2012](https://lists.archlinux.org/pipermail/arch-dev-public/2012-March/022690.html)