### PR TITLE
Include --expert when editing master key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1704,7 +1704,7 @@ Edit the master key:
 ```console
 $ export KEYID=0xFF3E7D88647EBCDB
 
-$ gpg --edit-key $KEYID
+$ gpg --expert --edit-key $KEYID
 
 Secret key is available
 [...]


### PR DESCRIPTION
This is specifically during setup when rotating keys. I didn't notice that `--expert` was missing and I wasn't able to create an RSA key with custom capabilities.