### PR TITLE
Fix order of revocation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,7 +881,7 @@ Even worse, we cannot advertise this fact in any way to those that are using our
 To create the revocation certificate:
 
 ``` console
-$ gpg --gen-revoke $KEYID --output $GNUPGHOME/revoke.asc
+$ gpg --output $GNUPGHOME/revoke.asc --gen-revoke $KEYID
 ```
 
 The `revoke.asc` certificate file should be stored (or printed) in a (secondary) place that allows retrieval in case the main backup fails.


### PR DESCRIPTION
While following the instructions (using the Debian live system) I noticed that the command to create the revocation file was in incorrect order and would always produce an error.

According to `man gpg` the order of arguments should be

`gpg [--homedir name] [--options file] [options] command [args]`

In this case `--gen-revoke` is the command, `$KEYID` is an argument and
`--output $GNUPGHOME/revoke.asc` is an option. Previously this was
incorrect (the command came first) and would spawn an error.