### PR TITLE
Set touch policy to fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2256,19 +2256,19 @@ To require a touch for each key operation, install [YubiKey Manager](https://dev
 Authentication:
 
 ```console
-$ ykman openpgp set-touch aut on
+$ ykman openpgp set-touch aut fixed
 ```
 
 Signing:
 
 ```console
-$ ykman openpgp set-touch sig on
+$ ykman openpgp set-touch sig fixed
 ```
 
 Encryption:
 
 ```console
-$ ykman openpgp set-touch enc on
+$ ykman openpgp set-touch enc fixed
 ```
 
 YubiKey will blink when it is waiting for a touch. On Linux you can also use [yubikey-touch-detector](https://github.com/maximbaz/yubikey-touch-detector) to have an indicator or notification that YubiKey is waiting for a touch.


### PR DESCRIPTION
Setting the touch policy to `on` does not prevent the policy from
later being turned off again. Setting it to `fixed` is more secure
because it can not be turned off.

If someone wants to disable the touch policy they can always restore
the keys from the backups created in the guide.