### PR TITLE
fixing wrong cryptography version

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ To install and use the `ykman` utility:
 ```console
 $ sudo apt -y install python-pip python-pyscard
 
+$ pip install PyOpenSSL
+
 $ pip install yubikey-manager
 
 $ sudo service pcscd start


### PR DESCRIPTION
fixing wrong cryptography version by explicitly installing PyOpenSSL

see also the issue https://github.com/drduh/YubiKey-Guide/issues/202