### PR TITLE
unset GNUPGHOME variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1500,6 +1500,8 @@ Reboot or [securely delete](http://srm.sourceforge.net/) `$GNUPGHOME` and remove
 $ sudo srm -r $GNUPGHOME || sudo rm -rf $GNUPGHOME
 
 $ gpg --delete-secret-key $KEYID
+
+$ unset GNUPGHOME
 ```
 
 **Important** Make sure you have securely erased all generated keys and revocation certificates if an ephemeral enviroment was not used!


### PR DESCRIPTION
if not done, in the next step you get error: 

```
gpg: keyblock resource '/home/..../gnupg-workspace/pubring.kbx': No such file or directory
gpg: no writable keyring found: Not found
```