### PR TITLE
Add New Agent Forward Method and Clarify Two Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1979,8 +1979,9 @@ export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
 gpgconf --launch gpg-agent
 ```
 
-Note that `SSH_AUTH_SOCK` normally only needs to be set on the *local* laptop (workstation), where the YubiKey is plugged in.  On the *remote* server that we SSH into, `ssh` will automatically set `SSH_AUTH_SOCK` to something like `/tmp/ssh-mXzCzYT2Np/agent.7541` when we connect.  We therefore do **NOT** manually set `SSH_AUTH_SOCK` on the server - doing so would break [SSH Agent Forwarding](#remote-machines-gpg-agent-forwarding).
+Note that if you use `ForwardAgent` for ssh-agent forwarding, `SSH_AUTH_SOCK` only needs to be set on the *local* laptop (workstation), where the YubiKey is plugged in.  On the *remote* server that we SSH into, `ssh` will automatically set `SSH_AUTH_SOCK` to something like `/tmp/ssh-mXzCzYT2Np/agent.7541` when we connect.  We therefore do **NOT** manually set `SSH_AUTH_SOCK` on the server - doing so would break [SSH Agent Forwarding](#remote-machines-ssh-agent-forwarding).
 
+If you use `S.gpg-agent.ssh` (see [SSH Agent Forwarding](#remote-machines-ssh-agent-forwarding) for more info), `SSH_AUTH_SOCK` should also be set on the *remote*. However, `GPG_TTY` should not be set on the *remote*, explanation specified in that section.
 
 ## Copy public key
 

--- a/README.md
+++ b/README.md
@@ -2234,7 +2234,7 @@ The goal here is to make the SSH client inside WSL work together with the Window
 
 #### Use ssh-agent or use S.weasel-pegant
 
-One way to forward is just `ssh -A` (still need to eval weasel to setup local ssh-agent), and only relies on OpenSSH. In this track, `ForwardAgent` and `AllowAgentForwarding` may be involved. Otherwise they are of no use or even harm the forwarding. See [SSH Agent Forwarding](#remote-machines-ssh-agent-forwarding) for more info.
+One way to forward is just `ssh -A` (still need to eval weasel to setup local ssh-agent), and only relies on OpenSSH. In this track, `ForwardAgent` and `AllowAgentForwarding` in ssh/sshd config may be involved; However, if you use the other way(gpg ssh socket forwarding), you should not enable `ForwardAgent` in ssh config. See [SSH Agent Forwarding](#remote-machines-ssh-agent-forwarding) for more info.
 
 Another way is to forward the gpg ssh socket, as described below.
 

--- a/README.md
+++ b/README.md
@@ -2124,6 +2124,8 @@ After typing or sourcing your shell rc file, with `ssh-add -l` you should find y
 
 **Note** In this process no gpg-agent in the remote is involved, hence `gpg-agent.conf` in the remote is of no use. Also pinentry is invoked locally.
 
+**Note** Agent forwarding may be chained through multiple hosts
+
 ## GitHub
 
 You can use YubiKey to sign GitHub commits and tags. It can also be used for GitHub SSH authentication, allowing you to push, pull, and commit without a password.
@@ -2331,6 +2333,8 @@ extra-socket /run/user/1000/gnupg/S.gpg-agent.extra
 **Note** The pinentry program starts on *local* machine, not remote. Hence when there are needs to enter the pin you need to find the prompt on local machine.
 
 **Important** Any pinentry program except `pinentry-tty` or `pinentry-curses` may be used. This is because local `gpg-agent` may start headlessly (By systemd without `$GPG_TTY` set locally telling which tty it is on), thus failed to obtain the pin. Errors on the remote may be misleading saying that there is *IO Error* (Yes internally there is actually *IO Error* since it happens when writing to/reading from tty while finding no tty to use, but for end users this is not friendly).
+
+**Note** Agent forwarding may be chained through multiple hosts
 
 See [Issue #85](https://github.com/drduh/YubiKey-Guide/issues/85) for more information and troubleshooting.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ If you have a comment or suggestion, please open an [Issue](https://github.com/d
   * [OpenBSD](#openbsd-1)
   * [Windows](#windows-1)
     + [WSL](#wsl)
+      - [Use ssh-agent or use S.weasel-pegant](#use-ssh-agent-or-use-sweasel-pegant)
       - [Prerequisites](#prerequisites)
       - [WSL configuration](#wsl-configuration)
       - [Remote host configuration](#remote-host-configuration)
@@ -2212,6 +2213,12 @@ The goal here is to make the SSH client inside WSL work together with the Window
 
 **Note** this works only for SSH agent forwarding. Real GPG forwarding (encryption/decryption) is actually not supported. See the [weasel-pageant](https://github.com/vuori/weasel-pageant) readme for further information.
 
+#### Use ssh-agent or use S.weasel-pegant
+
+One way to forward is just `ssh -A` (still need to eval weasel to setup local ssh-agent), and only relies on OpenSSH. In this track, `ForwardAgent` and `AllowAgentForwarding` may be involved. Otherwise they are of no use or even harm the forwarding. See [SSH Agent Forwarding](#remote-machines-ssh-agent-forwarding) for more info.
+
+Another way is to forward the gpg ssh socket, as described below.
+
 #### Prerequisites
 
 * Ubuntu 16.04 or newer for WSL
@@ -2229,7 +2236,6 @@ Display the SSH key with `$ ssh-add -l`
 Edit `~/.ssh/config` to add the following for each host you want to use agent forwarding:
 
 ```
-ForwardAgent yes
 RemoteForward <remote SSH socket path> /tmp/S.weasel-pageant
 ```
 
@@ -2237,17 +2243,15 @@ RemoteForward <remote SSH socket path> /tmp/S.weasel-pageant
 
 #### Remote host configuration
 
-You may have to add the following to the shell rc file. On Linux, this is only required on the laptop/workstation where the YubiKey is plugged in, and **NOT** on the remote host server that you connect to; in fact at least on some Linux distributions, changing SSH_AUTH_SOCK on the server breaks agent forwarding.
+You may have to add the following to the shell rc file. 
 
 ```
 export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
-export GPG_TTY=$(tty)
 ```
 
 Add the following to `/etc/ssh/sshd_config`:
 
 ```
-AllowAgentForwarding yes
 StreamLocalBindUnlink yes
 ```
 


### PR DESCRIPTION
Big PR! Changes involving multiple sections, and multiple reviewers/assignees may be needed.

There are two agents when coping with ssh and gpg, namely gpg-agent and ssh-agent. GPG-Agent has a broader usage as it can emulate an ssh-agent.

Forwarding of agents is needed by many, and it is one benefit of agents as it separates the logic of one program. However, it may be confusing or even misleading for new users, especially when there are two agents. 

Unfortunately, in this README, two agents are mixed, hence **two ways of agent forwarding are mixed or only one of them is explained**. This may lead to configuration errors hence forwarding may not work.

Changes made are explained in commit messages, below is the summary of changes made.

1. Separate GPG-Agent forwarding from SSH section as a standalone section;
2. Introduce a new method of ssh agent forwarding and clarify the distinction;
3. Add some practice experience and analyses in these sections;
4. Adjust other configs involving agent forwarding to fit the distinction between methods introduced above.