### PR TITLE
Support android password store

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,11 @@ use-agent
 throw-keyids
 ```
 
+If you want to use [Password Store](https://github.com/android-password-store/Android-Password-Store) and/or [Openkeychain](https://www.openkeychain.org/) on Android, `throw-keyids` must be disabled 
+(see [1](https://github.com/android-password-store/Android-Password-Store/issues/173) or 
+[2](https://github.com/open-keychain/open-keychain/issues/1781)). For this 
+reason, I strongly recommended commenting `#throw-keyids` on your `gpg.conf`.
+
 Disable networking for the remainder of the setup.
 
 # Master key

--- a/README.md
+++ b/README.md
@@ -436,9 +436,9 @@ If you want to use [Password Store](https://github.com/android-password-store/An
 [2](https://github.com/open-keychain/open-keychain/issues/1781)). For this 
 reason, I strongly recommended commenting `#throw-keyids` on your `gpg.conf`.
 
-Disable networking for the remainder of the setup.
-
 # Master key
+
+**Important: disable networking** for the remainder of the setup.
 
 The first key to generate is the master key. It will be used for certification only: to issue sub-keys that are used for encryption, signing and authentication.
 


### PR DESCRIPTION
It seems that `throw-keyids` option must be disable to work with "open source" tools for GPG.