### PR TITLE
Add SSH setup for macOS GUI applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ If you have a comment or suggestion, please open an [Issue](https://github.com/d
       - [Prerequisites](#prerequisites)
       - [WSL configuration](#wsl-configuration)
       - [Remote host configuration](#remote-host-configuration)
+  * [macOS](#macos-1)
 - [Remote Machines (GPG Agent Forwarding)](#remote-machines-gpg-agent-forwarding)
   * [Steps for older distributions](#steps-for-older-distributions)
   * [Chained GPG Agent Forwarding](#chained-gpg-agent-forwarding)
@@ -2187,10 +2188,10 @@ $ doas reboot
 
 Windows can already have some virtual smartcard readers installed, like the one provided for Windows Hello. To ensure your YubiKey is the correct one used by scdaemon, you should add it to its configuration. You will need your device's full name. To find out what is your device's full name, plug your YubiKey and open PowerShell to run the following command:
 
-```` powershell
+``` powershell
 PS C:\WINDOWS\system32> Get-PnpDevice -Class SoftwareDevice | Where-Object {$_.FriendlyName -like "*YubiKey*"} | Select-Object -ExpandProperty FriendlyName
 Yubico YubiKey OTP+FIDO+CCID 0
-````
+```
 
 The name slightly differs according to the model. Thanks to [Scott Hanselman](https://www.hanselman.com/blog/HowToSetupSignedGitCommitsWithAYubiKeyNEOAndGPGAndKeybaseOnWindows.aspx) for sharing this information.
 
@@ -2286,6 +2287,64 @@ Log in to the remote host, you should have the pinentry dialog asking for the Yu
 On the remote host, type `ssh-add -l` - if you see the ssh key, that means forwarding works!
 
 **Note** Agent forwarding may be chained through multiple hosts - just follow the same [protocol](#remote-host-configuration) to configure each host. You may also read this part on [chained ssh agent forwarding](#chained-ssh-agent-forwarding).
+
+## macOS
+
+To use gui applications on macOS, [a little bit more setup is needed](https://jms1.net/yubikey/make-ssh-use-gpg-agent.md).
+
+Create `$HOME/Library/LaunchAgents/gnupg.gpg-agent.plist` with the following contents:
+
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key>
+        <string>gnupg.gpg-agent</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <false/>
+        <key>ProgramArguments</key>
+        <array>
+            <string>/usr/local/MacGPG2/bin/gpg-connect-agent</string>
+            <string>/bye</string>
+        </array>
+    </dict>
+</plist>
+```
+
+```console
+launchctl load gnupg.gpg-agent.plist
+```
+
+Create `$HOME/Library/LaunchAgents/gnupg.gpg-agent-symlink.plist` with the following contens:
+
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/ProperyList-1.0/dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key>
+        <string>gnupg.gpg-agent-symlink</string>
+        <key>ProgramArguments</key>
+        <array>
+            <string>/bin/sh</string>
+            <string>-c</string>
+            <string>/bin/ln -sf $HOME/.gnupg/S.gpg-agent.ssh $SSH_AUTH_SOCK</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+    </dict>
+</plist>
+```
+
+```console
+launchctl load gnupg.gpg-agent-symlink.plist
+```
+
+You will need to either reboot, or log out and log back in, in order to activate these changes.
 
 # Remote Machines (GPG Agent Forwarding)
 


### PR DESCRIPTION
On macOS, a LaunchAgent needs to be created to overwrite the system's SSH agent.

see 
- https://github.com/drduh/YubiKey-Guide/issues/229
- https://evilmartians.com/chronicles/stick-with-security-yubikey-ssh-gnupg-macos
- https://jms1.net/yubikey/make-ssh-use-gpg-agent.md