### PR TITLE
Fix: "quit" to save -> "save" to save

### DIFF
--- a/README.md
+++ b/README.md
@@ -1844,7 +1844,7 @@ Please specify how long the key should be valid.
       <n>y = key expires in n years
 Key is valid for? (0)
 ```
-Follow these prompts to set a new expiration date, then `quit` to save your changes.
+Follow these prompts to set a new expiration date, then `save` to save your changes.
 
 Next, export your public key:
 


### PR DESCRIPTION
The current advice to use `quit` at the end of the key renewal section seems dangerously wrong: `quit` does not save any changes.

https://www.gnupg.org/gph/en/manual/r899.html