### PR TITLE
Script to switch between two Yubikeys with identical keys

### DIFF
--- a/switch-to-backup-yubikey
+++ b/switch-to-backup-yubikey
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# To make a duplicate Yubikey for GPG keys
+# 1. Insert Yubikey1
+# 2. Create keys/subkeys
+# 3. Run keytocard to transfer keys to Yubikey1
+# 4. QUIT WITHOUT SAVING!!!!! 
+#
+# This will leave the keys on the Yubikey but NOT change the 
+# GPG keyring to point to the Yubikey1 with a stub
+# 
+# 5. Insert Yubikey2
+# 6. Run keytocard to transfer keys to Yubikey2
+# 7. QUIT and SAVE to make GPG point it's stubs to Yubikey2
+#
+# Running any decrypt, auth or sign will now ask you to insert Yubikey2
+# To switch to Yubikey1 at any time run this script to force GPG 
+# to repoint the key stubs to the inserted Yubikey
+
+read -p "Insert the Yubikey you want to use ....  "   ignore
+echo "Switching GPG to backup Yubikey ..."
+
+gpg-connect-agent "scd serialno" "learn --force" /bye


### PR DESCRIPTION
Some GitHub users have asked in the issues why can't I use two Yubikeys (one as a backup). It's a question often asked 

The usual answer given across the web is that you can't as GPG replaces the key with key stubs when you quit and save (if you don't save then the Yubikey appears useless as GPG doesn't delete the keys and carries on using them off the keyring.

If once you have run keytocard to transfer your keys to the Yubikey#1 you QUIT WITHOUT SAVING then you can repeat the whole process again and put in your Yubikey#2 and keytocard again. this time QUIT AND SAVE.

GPG will now replace the keys with a key stub pointing to the Yubikey with the card serial number (see Yubikey serial on back of key) when you try to decrypt/sign/authenticate. The first Yubikey will be ignored despite the fact it has a copy of the Yubikey.

However you can use gpg-connect-agent to force read the Yubikey and repoint the key stubs to the keys on the Yubikey inserted.

Just run the script and insert whichever key you have to have (primary or backup) when prompted 

NB once this script has been run GPG will be pointing the stubs at the recently used Yubikey ... to go back to your first Yubikey again switch Yubikeys and re-run script

Simples :)