### PR TITLE
Update nixos LiveCD example

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Generate a NixOS LiveCD image with the given config:
 let
   config = { pkgs, ... }:
   with pkgs; {
-    imports = [ <nixpkgs/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix> ];
+    imports = [ <nixpkgs/nixos/modules/installer/cd-dvd/installation-cd-graphical-plasma5.nix> ];
 
     boot.kernelPackages = linuxPackages_latest;
 


### PR DESCRIPTION
````nixpkgs/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix```` no longer exists. 
Update to ````nixpkgs/nixos/modules/installer/cd-dvd/installation-cd-graphical-plasma5.nix````