### PR TITLE
Replace deprecated command for changing puk with recommended command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1337,7 +1337,7 @@ Your selection? q
 The PUK (Pin Unlock Key) can be used to reset the PIN if it is ever lost or becomes blocked after the maximum number of incorrect attempts (default 3). The default PUK is `12345678`. If the PUK is also entered incorrectly three times, the key is permanently irrecoverable. You can set your PUK to the same as your daily PIN, giving you a total of 6 attempts.
 
 ```console
-ykman piv change-puk
+ykman piv access change-puk
 
 Enter your current PUK:
 Enter your new PUK:


### PR DESCRIPTION
The current command for changing the puk, ykman piv change-puk,
throws the following warning and recommended change:
WARNING: The use of this command is deprecated and will be removed!
Replace with: ykman piv access change-puk