### PR TITLE
chore: add piv-agent to Alternatives section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2749,7 +2749,7 @@ Before you unmount your backup, ask yourself if you should make another one just
 
 # Alternatives
 
-*TODO: Information about other ways to authenticate SSH (e.g., without GPG) and other YubiKey features*
+* [`piv-agent`](https://github.com/smlx/piv-agent) is an SSH and GPG agent which you can use with your PIV hardware security device (e.g. a Yubikey).
 
 # Links
 


### PR DESCRIPTION
This PR adds `piv-agent` to the list of alternatives. It provides another way to use a Yubikey with `gpg` and `ssh` backed by the PIV applet instead of the OpenPGP applet.