### PR TITLE
Possible fix for the 'signing failed: agent refused operation' error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2718,6 +2718,8 @@ Before you unmount your backup, ask yourself if you should make another one just
 
 - If you still receive the error, `sign_and_send_pubkey: signing failed: agent refused operation` - edit `~/.gnupg/gpg-agent.conf` to set a valid `pinentry` program path, e.g. `pinentry-program /usr/local/bin/pinentry-mac` on macOS.
 
+- If you still receive the error, `sign_and_send_pubkey: signing failed: agent refused operation` - it is a [known issue](https://bbs.archlinux.org/viewtopic.php?id=274571) that openssh 8.9p1 and higher has issues with YubiKey. Adding `KexAlgorithms -sntrup761x25519-sha512@openssh.com` to `/etc/ssh/ssh_config` often resolves the issue.
+
 - If you receive the error, `The agent has no identities` from `ssh-add -L`, make sure you have installed and started `scdaemon`.
 
 - If you receive the error, `Error connecting to agent: No such file or directory` from `ssh-add -L`, the UNIX file socket that the agent uses for communication with other processes may not be set up correctly. On Debian, try `export SSH_AUTH_SOCK="/run/user/$UID/gnupg/S.gpg-agent.ssh"`. Also see that `gpgconf --list-dirs agent-ssh-socket` is returning single path, to existing `S.gpg-agent.ssh` socket.


### PR DESCRIPTION
See [This ArchLinux BBS Topic](https://bbs.archlinux.org/viewtopic.php?id=274571) for more info. OpenSSH 8.9p1 and OpenSSH 9
appear to break Yubikey client authentication.