### PR TITLE
Add Fedora required software section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ If you have a comment or suggestion, please open an [Issue](https://github.com/d
 - [Prepare environment](#prepare-environment)
 - [Required software](#required-software)
   * [Debian and Ubuntu](#debian-and-ubuntu)
+  * [Fedora](#fedora)
   * [Arch](#arch)
   * [RHEL7](#rhel7)
   * [NixOS](#nixos)
@@ -241,6 +242,15 @@ $ pip3 install yubikey-manager
 $ sudo service pcscd start
 
 $ ~/.local/bin/ykman openpgp info
+```
+
+## Fedora
+```console
+$ sudo dnf install wget
+$ wget https://github.com/rpmsphere/noarch/raw/master/r/rpmsphere-release-34-2.noarch.rpm
+$ sudo rpm -Uvh rpmsphere-release*rpm
+
+$ sudo dnf install gnupg2 dirmngr cryptsetup gnupg2-smime pcsc-tools opensc pcsc-lite secure-delete pgp-tools yubikey-personalization-gui
 ```
 
 ## Arch


### PR DESCRIPTION
I created this PR to create a required software section for Fedora. I believe all software is in the packages but I only use this guide for SSH with a yubikey and those packages worked for me. 

Unfortunately, you have to add the `rpmsphere-release` repository for the `secure-delete` package.