### PR TITLE
Update the command to change the pin retry attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1355,7 +1355,7 @@ Your selection? q
 The number of retry attempts can be changed with the following command, documented [here](https://docs.yubico.com/software/yubikey/tools/ykman/OpenPGP_Commands.html#ykman-openpgp-access-set-retries-options-pin-retries-reset-code-retries-admin-pin-retries):
 
 ```bash
-ykman openpgp access set-retries 5 5 5
+ykman openpgp set-pin-retries 5 5 5
 ```
 
 ## Set information


### PR DESCRIPTION
I Installed the `ykman` with `sudo apt install yubikey-manager` in a Ubuntu 20.04 and noticed that the command to change the pin retry attempts has chaged.
This PR updates the documentations with the new command