### PR TITLE
Reorder cleanup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1669,9 +1669,9 @@ Ensure you have:
 Reboot or [securely delete](http://srm.sourceforge.net/) `$GNUPGHOME` and remove the secret keys from the GPG keyring:
 
 ```console
-$ sudo srm -r $GNUPGHOME || sudo rm -rf $GNUPGHOME
-
 $ gpg --delete-secret-key $KEYID
+
+$ sudo srm -r $GNUPGHOME || sudo rm -rf $GNUPGHOME
 
 $ unset GNUPGHOME
 ```


### PR DESCRIPTION
If I try to delete the directory and then issue the `gpg --delete-secret-key $KEYID` command gpg gets very confused

```
gpg: keyblock resource '/var/folders/5d/wdpp...<blah>...000gn/T/gnupg_blah/pubring.kbx': No such file or directory
gpg: key "0x690...<blah>...ABF01" not found: Not found
gpg: 0x690...<blah>...ABF01: delete key failed: Not found
```