### PR TITLE
add notes for installing #Required Software on Debian 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,25 @@ $ sudo apt update ; sudo apt -y upgrade
 $ sudo apt -y install wget gnupg2 gnupg-agent dirmngr cryptsetup scdaemon pcscd secure-delete hopenpgp-tools yubikey-personalization
 ```
 
+**Note**
+As of 2023 June, the `hopenpgp-tools` is not part of the latest Debian 12 stable package repositories.
+
+To install it, go to [https://packages.debian.org/sid/hopenpgp-tools](https://packages.debian.org/sid/hopenpgp-tools) to select your architecture and then an ftp server.
+
+Edit `/etc/apt/sources.list` and add the ftp server:
+```
+deb http://ftp.debian.org/debian sid main
+```
+
+and then add this to `/etc/apt/preferences` (or a fragment, e.g. `/etc/apt/preferences.d/00-sid`) so that APT still prioritizes packages from the stable repository over sid.
+
+```
+Package: *
+Pin: release n=sid
+Pin-Priority: 10
+```
+
+
 **Note** Live Ubuntu images [may require modification](https://github.com/drduh/YubiKey-Guide/issues/116) to `/etc/apt/sources.list` and may need additional packages:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -254,6 +254,9 @@ $ sudo service pcscd start
 $ ~/.local/bin/ykman openpgp info
 ```
 
+**Note** Debian 12 doesn't recommend installing non-Debian packaged Python applications globally. But fortunately, it isn't even necessary as `yubikey-manager` is available in the stable main repository:
+`$ sudo apt install yubikey-manager`.
+
 ## Fedora
 
 ```console


### PR DESCRIPTION
Added a note on installing `hopenpgp-tools` as it isn't included in the stable Debian 12 repositories or the backports, but it is available in the sid.

On the other hand, `yubikey-manager` is available in the stable repository and, on Debian 12, installing `python3-pip`, `python3-pyscard` and `pip install PyOpenSSL` is not necessary, so I also added a note on that.

related to https://github.com/drduh/YubiKey-Guide/issues/389