### PR TITLE
fix: add an explicit example about publishing the pubkey when expiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -2026,7 +2026,7 @@ Key is valid for? (0)
 ```
 Follow these prompts to set a new expiration date, then `save` to save your changes.
 
-Next, export the public key:
+Next, [export the public key](#export-public-keys):
 
 ```console
 $ gpg --armor --export $KEYID > gpg-$KEYID-$(date +%F).asc
@@ -2036,6 +2036,18 @@ Transfer that public key to the computer from which you use your GPG key, and th
 
 ```console
 $ gpg --import gpg-0x*.asc
+```
+
+Alternatively, use a public key server (it will update the key if already on the server):
+
+```console
+$ gpg --send-key $KEYID
+```console
+
+and import the newly  on any computer where you wish to use it (it will update the key if previously imported):
+
+```console
+$ gpg --recv $KEYID
 ```
 
 This will extend the validity of your GPG key and will allow you to use it for SSH authorization.  Note that you do _not_ need to update the SSH public key located on remote servers.

--- a/README.md
+++ b/README.md
@@ -2042,7 +2042,7 @@ Alternatively, use a public key server (it will update the key if already on the
 
 ```console
 $ gpg --send-key $KEYID
-```console
+```
 
 and import the newly updated key on any computer where you wish to use it (it will update the key if previously imported):
 

--- a/README.md
+++ b/README.md
@@ -2044,7 +2044,7 @@ Alternatively, use a public key server (it will update the key if already on the
 $ gpg --send-key $KEYID
 ```console
 
-and import the newly  on any computer where you wish to use it (it will update the key if previously imported):
+and import the newly updated key on any computer where you wish to use it (it will update the key if previously imported):
 
 ```console
 $ gpg --recv $KEYID


### PR DESCRIPTION
It's explained in the text, but there's no example.