### PR TITLE
Required Software/NixOS: Replace yubioath-desktop with yubioath-flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ let
         yubikey-personalization
         yubikey-personalization-gui
         yubico-piv-tool
-        yubioath-desktop
+        yubioath-flutter
 
         # Testing
         ent


### PR DESCRIPTION
Trying to use `yubioath-desktop` results on this error:

```console
yubioath-desktop has been deprecated by upstream in favor of yubioath-flutter
```

On the current stable channel (23.05).