### PR TITLE
Add link to "makegpg" tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -3214,6 +3214,7 @@ Continue with the Verify section of this guide.
 
 # Links
 
+* [Minimal key management tool written for this guide](https://gitlab.com/lsasolutions/makegpg)
 * https://alexcabal.com/creating-the-perfect-gpg-keypair/
 * https://blog.habets.se/2013/02/GPG-and-SSH-with-Yubikey-NEO
 * https://blog.josefsson.org/2014/06/23/offline-gnupg-master-key-and-subkeys-on-yubikey-neo-smartcard/


### PR DESCRIPTION
I wrote a quick tool that could be useful to others called `makegpg`. I wonder if you'd like to link to it? Many things are missing relative to your guide, but one addition is a backup / export system that also puts recovery scripts next to the backed-up keys and tests the keys as they are generated. Happy to license this tool in a compatible way and accept improvements from you and your users.

From its README:

```
 This tool creates and maintains a GPG keyring with a private key according to DrDuh's guide:
 https://github.com/drduh/YubiKey-Guide

 Initially, this repository is used to generate a set of keys. Once this set of keys are
 generated, this repository contains secrets that should be kept offline. In operation,
 this repository is used to renew (sub-)keys, make backups, and perform other functions.

 key creation and manipulation

    make private-key         guide user to create a new private key (and the `keyring` directory)
    make offline             download any files needed for offline key creation
    make edit                manually edit the master key
    make lint                check keys for issues

 backup and exporting (note: each of these runs a test on the generated files)

    make export              copy public key to the `exported` folder with today's date
    make backup              copy private keys and trust db to `backups` folder with today's date

 maintenance

    make stubs               recreate the GPG stubs that point to a YubiKey
    make renew               guide user through renewing subkeys
    make help                show this help text
```