### PR TITLE
Update rpmsphere version

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ $ ~/.local/bin/ykman openpgp info
 
 ```console
 $ sudo dnf install wget
-$ wget https://github.com/rpmsphere/noarch/raw/master/r/rpmsphere-release-34-2.noarch.rpm
+$ wget https://github.com/rpmsphere/noarch/raw/master/r/rpmsphere-release-38-1.noarch.rpm
 $ sudo rpm -Uvh rpmsphere-release*rpm
 
 $ sudo dnf install gnupg2 dirmngr cryptsetup gnupg2-smime pcsc-tools opensc pcsc-lite secure-delete pgp-tools yubikey-personalization-gui


### PR DESCRIPTION
This just updates the rpmsphere version to the latest; the current link is dead. In the long run, a way to automatically get the latest version would probably be a better idea, though.