### PR TITLE
Quote Debian Live ISO URL, and add $ to AWK RegExp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ This guide recommends using a bootable "live" Debian Linux image to provide such
 To use Debian Live, download the latest image:
 
 ```console
-$ curl -LfO https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/SHA512SUMS
+$ curl -fLO https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/SHA512SUMS
 
-$ curl -LfO https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/SHA512SUMS.sign
+$ curl -fLO https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/SHA512SUMS.sign
 
-$ curl -LfO https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/$(awk '/xfce.iso/ {print $2}' SHA512SUMS)
+$ curl -fLO "https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/$(awk '/xfce.iso$/ {print $2}' SHA512SUMS)"
 ```
 
 Verify the signature of the hashes file with GPG:


### PR DESCRIPTION
Quote ISO URL, and add `$` RegExp end-of-string anchor to return only the ISO file and none of the other entries that contain `xfce.iso`.

This avoids unnecessary cURL errors.