### PR TITLE
add step to set `disable-ccid` in `scdaemon.conf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1930,7 +1930,7 @@ $ chmod 600 gpg.conf
 Set the following option. This avoids the problem where GnuPG will prompt, repeatedly, for the insertion of an already-inserted YubiKey:
 
 ```console
-$ echo "disable-ccid" >>~/scdaemon.conf
+$ echo "disable-ccid" >>scdaemon.conf
 ```
 
 >  The `disable-ccid` option is only required for GnuPG versions 2.3 or later. However, setting this option does not appear to interfere with the operation of earlier versions of GnuPG so it is recommended for all installations.

--- a/README.md
+++ b/README.md
@@ -1907,13 +1907,33 @@ $ unset GNUPGHOME
 
 # Using keys
 
+The following command creates and initialises the `~/.gnupg` if it does not exist already:
+
+```console
+$ gpg -k
+```
+
+Change your working directory:
+
+```console
+$ cd ~/.gnupg
+```
+
 Download [drduh/config/gpg.conf](https://github.com/drduh/config/blob/master/gpg.conf):
 
 ```console
-$ cd ~/.gnupg ; wget https://raw.githubusercontent.com/drduh/config/master/gpg.conf
+$ wget https://raw.githubusercontent.com/drduh/config/master/gpg.conf
 
 $ chmod 600 gpg.conf
 ```
+
+Set the following option. This avoids the problem where GnuPG will prompt, repeatedly, for the insertion of an already-inserted YubiKey:
+
+```console
+$ echo "disable-ccid" >>~/scdaemon.conf
+```
+
+>  The `disable-ccid` option is only required for GnuPG versions 2.3 or later. However, setting this option does not appear to interfere with the operation of earlier versions of GnuPG so it is recommended for all installations.
 
 Install the required packages and mount the non-encrypted volume created earlier:
 


### PR DESCRIPTION
Issue #404 reports "GPG acts like my YubiKey isn't plugged in".

With GnuPG 2.3 and later, the system can get into a loop where it prompts for insertion of a YubiKey even though that YubiKey is already connected.

The solution for this is to set `disable-ccid` in `~/.gnupg/scdaemon.conf`.

Testing suggests setting `disable-ccid` does not interfere with earlier versions of GnuPG (eg 2.2.27 on Debian Bullseye or 2.2.40 on Debian Bookworm).

This problem has also been mentioned in #277 and #256. Including a step in the Guide to set `disable-ccid` may help minimise recurrence.

Also takes the opportunity to ensure `~/.gnupg` directory exists on a new system before downloading `gpg.conf`.

References:

* Ludovic Rousseau

	- [GnuPG and PC/SC conflicts](https://ludovicrousseau.blogspot.com/2019/06/gnupg-and-pcsc-conflicts.html)

* GnuPG.org:

	- [Scdaemon Options](https://www.gnupg.org/documentation/manuals/gnupg/Scdaemon-Options.html#index-disable_002dccid)

* YubiCo:

	- [Resolving GPG's CCID conflicts](https://support.yubico.com/hc/en-us/articles/4819584884124-Resolving-GPG-s-CCID-conflicts)
	- [Troubleshooting Issues with GPG](https://support.yubico.com/hc/en-us/articles/360013714479-Troubleshooting-Issues-with-GPG)

* Closed issues:

	- [277 pcscd: Error Reader Exclusive](https://github.com/drduh/YubiKey-Guide/issues/277)
	- [256 Update scdaemon.conf for gnupg 2.3 with MacOS (and possibly others)](https://github.com/drduh/YubiKey-Guide/issues/256)

Fixes #404