### PR TITLE
11feb24

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This is a guide to using [YubiKey](https://www.yubico.com/products/) as a [SmartCard](https://security.stackexchange.com/questions/38924/how-does-storing-gpg-ssh-private-keys-on-smart-cards-compare-to-plain-usb-drives) for storing GPG encryption, signing and authentication keys, which can also be used for SSH. Many of the principles in this document are applicable to other smart card devices.
 
-Keys stored on YubiKey are [non-exportable](https://web.archive.org/web/20201125172759/https://support.yubico.com/hc/en-us/articles/360016614880-Can-I-Duplicate-or-Back-Up-a-YubiKey-) (as opposed to filesystem-based keys that are stored on disk) and are convenient for everyday use. Instead of having to remember and enter complicated passphrases to unlock SSH/GPG keys, YubiKey needs only a physical touch after being unlocked with a PIN.
+Keys stored on YubiKey are [non-exportable](https://web.archive.org/web/20201125172759/https://support.yubico.com/hc/en-us/articles/360016614880-Can-I-Duplicate-or-Back-Up-a-YubiKey-) (as opposed to filesystem-based keys that are stored on disk), while remaining convenient for daily use. Instead of having to remember and enter complicated passphrases to unlock SSH/GPG keys, YubiKey needs only a physical touch after being unlocked with a PIN.
 
 **Security Note** If you followed this guide before Jan 2021, your GPG *PIN* and *Admin PIN* may be set to their default values (`123456` and `12345678` respectively). This would allow an attacker to use your YubiKey or reset your PIN. Please see the [Change PIN](#change-pin) section for details on how to change your PINs.
 
@@ -11,87 +11,87 @@ To suggest an improvement, please send a pull request or open an [issue](https:/
 - [Purchase](#purchase)
 - [Prepare environment](#prepare-environment)
 - [Required software](#required-software)
-  - [Debian and Ubuntu](#debian-and-ubuntu)
-  - [Fedora](#fedora)
-  - [Arch](#arch)
-  - [RHEL7](#rhel7)
-  - [NixOS](#nixos)
-  - [OpenBSD](#openbsd)
-  - [macOS](#macos)
-  - [Windows](#windows)
+   * [Debian and Ubuntu](#debian-and-ubuntu)
+   * [Fedora](#fedora)
+   * [Arch](#arch)
+   * [RHEL7](#rhel7)
+   * [NixOS](#nixos)
+   * [OpenBSD](#openbsd)
+   * [macOS](#macos)
+   * [Windows](#windows)
 - [Entropy](#entropy)
-  - [YubiKey](#yubikey)
-  - [OneRNG](#onerng)
+   * [YubiKey](#yubikey)
+   * [OneRNG](#onerng)
 - [Creating keys](#creating-keys)
-  - [Temporary working directory](#temporary-working-directory)
-  - [Harden configuration](#harden-configuration)
+   * [Temporary working directory](#temporary-working-directory)
+   * [Harden configuration](#harden-configuration)
 - [Certify key](#certify-key)
 - [Sign with existing key](#sign-with-existing-key)
 - [Subkeys](#subkeys)
-  - [Signing](#signing)
-  - [Encryption](#encryption)
-  - [Authentication](#authentication)
-  - [Add extra identities](#add-extra-identities)
+   * [Signing](#signing)
+   * [Encryption](#encryption)
+   * [Authentication](#authentication)
+   * [Add extra identities](#add-extra-identities)
 - [Verify](#verify)
 - [Export secret keys](#export-secret-keys)
 - [Revocation certificate](#revocation-certificate)
 - [Backup](#backup)
 - [Export public keys](#export-public-keys)
 - [Configure Smartcard](#configure-smartcard)
-  - [Enable KDF](#enable-kdf)
-  - [Change PIN](#change-pin)
-  - [Set information](#set-information)
+   * [Enable KDF](#enable-kdf)
+   * [Change PIN](#change-pin)
+   * [Set information](#set-information)
 - [Transfer keys](#transfer-keys)
-  - [Signing](#signing)
-  - [Encryption](#encryption)
-  - [Authentication](#authentication)
+   * [Signing](#signing-1)
+   * [Encryption](#encryption-1)
+   * [Authentication](#authentication-1)
 - [Verify card](#verify-card)
 - [Multiple YubiKeys](#multiple-yubikeys)
-  - [Switching between YubiKeys](#switching-between-yubikeys)
+   * [Switching between YubiKeys](#switching-between-yubikeys)
 - [Multiple Hosts](#multiple-hosts)
-- [Cleanup](#cleanup)
+- [Finish](#finish)
 - [Using keys](#using-keys)
 - [Rotating keys](#rotating-keys)
-  - [Setup environment](#setup-environment)
-  - [Renewing subkeys](#renewing-subkeys)
-  - [Rotating keys](#rotating-keys-1)
+   * [Setup environment](#setup-environment)
+   * [Renewing Subkeys](#renewing-subkeys)
+   * [Rotating keys](#rotating-keys-1)
 - [Adding notations](#adding-notations)
 - [SSH](#ssh)
-  - [Create configuration](#create-configuration)
-  - [Replace agents](#replace-agents)
-  - [Copy public key](#copy-public-key)
-  - [(Optional) Save public key for identity file configuration](#optional-save-public-key-for-identity-file-configuration)
-  - [Connect with public key authentication](#connect-with-public-key-authentication)
-  - [Import SSH keys](#import-ssh-keys)
-  - [Remote Machines (SSH Agent Forwarding)](#remote-machines-ssh-agent-forwarding)
-    - [Use ssh-agent](#use-ssh-agent)
-    - [Use S.gpg-agent.ssh](#use-sgpg-agentssh)
-    - [Chained SSH Agent Forwarding](#chained-ssh-agent-forwarding)
-  - [GitHub](#github)
-  - [OpenBSD](#openbsd)
-  - [Windows](#windows)
-    - [WSL](#wsl)
-      - [Use ssh-agent or use S.weasel-pageant](#use-ssh-agent-or-use-sweasel-pageant)
-      - [Prerequisites](#prerequisites)
-      - [WSL configuration](#wsl-configuration)
-      - [Remote host configuration](#remote-host-configuration)
-  - [macOS](#macos)
+   * [Create configuration](#create-configuration)
+   * [Replace agents](#replace-agents)
+   * [Copy public key](#copy-public-key)
+   * [(Optional) Save public key for identity file configuration](#optional-save-public-key-for-identity-file-configuration)
+   * [Connect with public key authentication](#connect-with-public-key-authentication)
+   * [Import SSH keys](#import-ssh-keys)
+   * [Remote Machines (SSH Agent Forwarding)](#remote-machines-ssh-agent-forwarding)
+      + [Use ssh-agent ](#use-ssh-agent)
+      + [Use S.gpg-agent.ssh](#use-sgpg-agentssh)
+      + [Chained SSH Agent Forwarding](#chained-ssh-agent-forwarding)
+   * [GitHub](#github)
+   * [OpenBSD](#openbsd-1)
+   * [Windows](#windows-1)
+      + [WSL](#wsl)
+         - [Use ssh-agent or use S.weasel-pageant](#use-ssh-agent-or-use-sweasel-pageant)
+         - [Prerequisites](#prerequisites)
+         - [WSL configuration](#wsl-configuration)
+         - [Remote host configuration](#remote-host-configuration)
+   * [macOS](#macos-1)
 - [Remote Machines (GPG Agent Forwarding)](#remote-machines-gpg-agent-forwarding)
-  - [Steps for older distributions](#steps-for-older-distributions)
-  - [Chained GPG Agent Forwarding](#chained-gpg-agent-forwarding)
+   * [Steps for older distributions](#steps-for-older-distributions)
+   * [Chained GPG Agent Forwarding](#chained-gpg-agent-forwarding)
 - [Using Multiple Keys](#using-multiple-keys)
 - [Adding an identity](#adding-an-identity)
-  - [Updating your YubiKey](#updating-your-yubikey)
+   * [Updating YubiKey](#updating-yubikey)
 - [Require touch](#require-touch)
 - [Email](#email)
-  - [Mailvelope on macOS](#mailvelope-on-macos)
-  - [Mutt](#mutt)
+   * [Mailvelope](#mailvelope)
+   * [Mutt](#mutt)
 - [Reset](#reset)
-- [Recovery after reset](#recovery-after-reset)
+   * [Recovery after reset](#recovery-after-reset)
 - [Notes](#notes)
 - [Troubleshooting](#troubleshooting)
 - [Alternatives](#alternatives)
-  - [Create keys with batch](#create-keys-with-batch)
+   * [Create keys with batch](#create-keys-with-batch)
 - [Additional resources](#additional-resources)
 
 # Purchase
@@ -102,18 +102,20 @@ To verify a YubiKey is genuine, open a [browser with U2F support](https://suppor
 
 This website verifies YubiKey device attestation certificates signed by a set of Yubico certificate authorities, and helps mitigate [supply chain attacks](https://media.defcon.org/DEF%20CON%2025/DEF%20CON%2025%20presentations/DEF%20CON%2025%20-%20r00killah-and-securelyfitz-Secure-Tokin-and-Doobiekeys.pdf).
 
-You will also need several small storage devices (microSD cards work well) for storing encrypted backups of your keys.
+You will also need several portable storage devices (microSD cards work well) for storing encrypted backups of your keys.
 
 # Prepare environment
 
-To create cryptographic keys, a secure environment that can be reasonably assured to be free of adversarial control is recommended. Here is a general ranking of environments most to least likely to be compromised:
+To create cryptographic keys, a secure environment that can be reasonably assured to be free of adversarial control is recommended.
 
-1. Daily-use operating system
-1. Virtual machine on daily-use host OS (using [virt-manager](https://virt-manager.org/), VirtualBox, or VMware)
+The following is a general ranking of environments most to least likely to be compromised:
+
+1. Daily-use system with full Internet access
+1. Virtual machine on daily-use host OS (using [virt-manager](https://virt-manager.org/), VirtualBox or VMware)
 1. Separate hardened [Debian](https://www.debian.org/) or [OpenBSD](https://www.openbsd.org/) installation which can be dual booted
 1. Live image, such as [Debian Live](https://www.debian.org/CD/live/) or [Tails](https://tails.boum.org/index.en.html)
 1. Secure hardware/firmware ([Coreboot](https://www.coreboot.org/), [Intel ME removed](https://github.com/corna/me_cleaner))
-1. Dedicated air-gapped system with no networking capabilities
+1. Dedicated air-gapped system without networking capabilities (Raspberry Pi or equivalent)
 
 This guide recommends using a bootable "live" Debian Linux image to provide such an environment, however, depending on your threat model, you may want to take fewer or more steps to secure it.
 
@@ -151,7 +153,7 @@ grep $(sha512sum debian-live-*-amd64-xfce.iso) SHA512SUMS
 
 See [Verifying authenticity of Debian CDs](https://www.debian.org/CD/verify) for more information.
 
-Mount a storage device and copy the image to it:
+Mount a portable storage device and copy the image:
 
 **Linux**
 
@@ -187,15 +189,15 @@ $ doas dd if=debian-live-*-amd64-xfce.iso of=/dev/rsd2c bs=4m
 1951432704 bytes transferred in 139.125 secs (14026448 bytes/sec)
 ```
 
-Shut down the computer and disconnect internal hard drives and all unnecessary peripheral devices. If being run within a VM, this part can be skipped as no such devices should be attached to the VM since the image will still be run as a "live image".
+Power off, then disconnect internal hard drives and all unnecessary devices, such as the wireless card.
 
 # Required software
 
 Boot the live image and configure networking.
 
-**Note** If the screen locks, unlock with `user`/`live`.
+**Note** If the screen locks, unlock with `user` / `live`
 
-Open the terminal and install required software packages.
+Open terminal and install required software packages.
 
 ## Debian and Ubuntu
 
@@ -246,8 +248,11 @@ sudo service pcscd start
 ~/.local/bin/ykman openpgp info
 ```
 
-**Note** Debian 12 doesn't recommend installing non-Debian packaged Python applications globally. But fortunately, it isn't even necessary as `yubikey-manager` is available in the stable main repository:
-`$ sudo apt install yubikey-manager`.
+**Note** Debian 12 does not recommend installing non-Debian packaged Python applications globally. But fortunately, it is not necessary as `yubikey-manager` is available in the stable main repository:
+
+```console
+sudo apt install yubikey-manager
+```
 
 ## Fedora
 
@@ -435,11 +440,11 @@ throw-keyids
 
 # Certify key
 
-The primary key to generate is the Certify key, which will be used to issue subkeys for Encrypt, Sign and Authenticate operations.
+The primary key to generate is the Certify key, which will be used to issue Subkeys for Encrypt, Sign and Authenticate operations.
 
-**Important** The Certify key should be kept offline at all times and only accessed from a secure environment to revoke or issue new subkeys. Keys can also be generated on the YubiKey itself to ensure no other copies exist, however for durability this guide recommends against it.
+**Important** The Certify key should be kept offline at all times and only accessed from a secure environment to revoke or issue new Subkeys. Keys can also be generated on the YubiKey itself to ensure no other copies exist, however for usability and durability reasons this guide recommends against doing so.
 
-Generate a passphrase which will be needed throughout the guide to create and export subkeys.
+Generate a passphrase which will be needed throughout the guide to create and export Subkeys.
 
 **Important** The passphrase should be memorized or written down in a secure place separate from the backup storage disk.
 
@@ -586,7 +591,7 @@ gpg  --default-key $OLDKEY --sign-key $KEYID
 
 # Subkeys
 
-Edit the identity to add subkeys:
+Edit the identity to add Subkeys:
 
 ```console
 $ gpg --expert --edit-key $KEYID
@@ -601,7 +606,7 @@ sec  rsa4096/0xEA5DE91459B80592
 
 Use of 4096-bit RSA keys is recommended.
 
-Subkeys are recommended to have one or several year expirations. They should be renewed using the offline Certify key. See [rotating keys](#rotating-keys).
+Subkeys are recommended to have one or several year expirations. They must be renewed using the Certify key. See [rotating keys](#rotating-keys).
 
 ## Signing
 
@@ -962,9 +967,7 @@ The `revoke.asc` certificate file should be stored (or printed) in a (secondary)
 
 # Backup
 
-Once keys are moved to YubiKey, they cannot be moved again!
-
-Create an **encrypted** backup of the keyring on removable media to be kept offline in a secure location.
+Create an **encrypted** backup on portable storage to be kept offline in a secure and durable location.
 	
 **Tip** The ext2 filesystem (without encryption) can be mounted on both Linux and OpenBSD. Consider using a FAT32/NTFS filesystem for MacOS/Windows compatibility instead.
 
@@ -974,7 +977,7 @@ It is strongly recommended to keep even encrypted OpenPGP private key material o
 
 **Linux**
 
-Attach another external storage device and check its label:
+Attach another portable storage device and check its label:
 
 ```console
 $ sudo dmesg | tail
@@ -1170,7 +1173,7 @@ See [OpenBSD FAQ#14](https://www.openbsd.org/faq/faq14.html#softraidCrypto) for 
 
 **Important** Without the *public* key, you will not be able to use GPG to encrypt, decrypt, nor sign messages. However, you will still be able to use YubiKey for SSH authentication.
 
-Create another partition on the removable storage device to store the public key, or reconnect networking and upload to a key server.
+Create another partition on the portable storage device to store the public key, or reconnect networking and upload to a key server.
 
 **Linux**
 
@@ -1397,7 +1400,7 @@ gpg/card> quit
 
 # Transfer keys
 
-**Important** Transferring keys to YubiKey using `keytocard` is a destructive, one-way operation only. Make sure you've made a backup before proceeding: `keytocard` converts the local, on-disk key into a stub, which means the on-disk copy is no longer usable to transfer to subsequent security key devices or mint additional keys.
+**Important** Transferring keys to YubiKey using `keytocard` is a one-way/destructive operation. Make sure a backup was made before proceeding. `keytocard` converts the local, on-disk key into a stub, which means the on-disk copy is no longer usable to transfer to subsequent YubiKeys.
 
 Previous GPG versions required the `toggle` command before selecting keys. The currently selected key(s) are indicated with an `*`. When moving keys only one key should be selected at a time.
 
@@ -1558,7 +1561,8 @@ Insert the first YubiKey (which has a different serial number) and run the follo
 ```console
 gpg-connect-agent "scd serialno" "learn --force" /bye
 ```
-GPG will then scan your first YubiKey for GPG keys and recreate the stubs to point to the GPG keyID and YubiKey Serial number of this first YubiKey.
+
+GPG will then scan your first YubiKey for GPG keys and recreate the stubs to point to the GPG keyID and YubiKey serial number of this first YubiKey.
 	
 To return to using the second YubiKey just repeat (insert other YubiKey and re-run command).
 	
@@ -1706,18 +1710,20 @@ Do you really want to set this key to ultimate trust? (y/N) y
 gpg> quit
 ```
 
-# Cleanup
+# Finish
 
-Before finishing the setup, ensure you have done the following:
+Before completing setup, verify the following:
 
-* Saved encryption, signing and authentication Subkeys to YubiKey (`gpg -K` should show `ssb>` for Subkeys).
-* Saved the YubiKey user and admin PINs which are different and were changed from default values.
-* Saved the password to the Certify key in a secure and durable location.
-* Saved a copy of the Certify key, Subkeys and revocation certificate on an encrypted volume, to be stored offline.
-* Saved the password to that LUKS-encrypted volume in a secure, long-term location (separate from the device itself).
-* Saved a copy of the public key somewhere easily accessible later.
+- [ ] Saved encryption, signing and authentication Subkeys to YubiKey (`gpg -K` should show `ssb>` for Subkeys)
+- [ ] Saved YubiKey user and admin PINs, which are unique and were changed from default values
+- [ ] Saved Certify key passphrase to a secure and durable location
+- [ ] Saved Certify key, Subkeys and revocation certificate on encrypted portable storage, to be kept offline
+- [ ] Saved password to encrypted volume on portable storage
+- [ ] Saved copy of public key where is can be easily accessed later
 
-Now reboot or [securely delete](https://srm.sourceforge.net/) `$GNUPGHOME` and remove the secret keys from the GPG keyring:
+Reboot to finish.
+
+If an ephemeral environment was not used for setup, delete secret keys from the keyring and [securely delete](https://srm.sourceforge.net/) `$GNUPGHOME`.
 
 ```console
 gpg --delete-secret-key $KEYID
@@ -1726,8 +1732,6 @@ sudo srm -r $GNUPGHOME || sudo rm -rf $GNUPGHOME
 
 unset GNUPGHOME
 ```
-
-**Important** Make sure you have securely erased all generated keys and revocation certificates if an ephemeral enviroment was not used!
 
 # Using keys
 
@@ -1759,14 +1763,16 @@ touch scdaemon.conf
 echo "disable-ccid" >>scdaemon.conf
 ```
 
->  The `disable-ccid` option is only required for GnuPG versions 2.3 or later. However, setting this option does not appear to interfere with the operation of earlier versions of GnuPG so it is recommended for all installations.
+> The `disable-ccid` option is only required for GnuPG versions 2.3 or later. However, setting this option does not appear to interfere with the operation of earlier versions of GnuPG so it is recommended for all installations.
 
 Install the required packages and mount the non-encrypted volume created earlier:
 
 **Linux**
 
 ```console
-sudo apt update && sudo apt install -y gnupg2 gnupg-agent gnupg-curl scdaemon pcscd
+sudo apt update
+
+sudo apt install -y gnupg2 gnupg-agent gnupg-curl scdaemon pcscd
 
 sudo mount /dev/mmcblk0p2 /mnt
 ```
@@ -1940,13 +1946,15 @@ document.pdf.1580000000.enc -> document.pdf
 
 # Rotating keys
 
-PGP does not provide forward secrecy - a compromised key may be used to decrypt all past messages. Although keys stored on YubiKey are difficult to steal, it is not impossible - the key and PIN could be taken, or a vulnerability may be discovered in key hardware or the random number generator used to create them, for example. Therefore, it is good practice to occassionally rotate Subkeys.
+PGP does not provide [forward secrecy](https://en.wikipedia.org/wiki/Forward_secrecy) - a compromised key may be used to decrypt all past messages. Although keys stored on YubiKey are difficult to steal, it is not impossible; the key and PIN could be taken, or a vulnerability may be discovered in key hardware or the random number generator used to create them, for example. Therefore, it is good practice to occassionally rotate Subkeys.
 
-When a Subkey expires, it can either be renewed or replaced. Both actions require access to the Certify key. Renewing Subkeys by updating their expiration date indicates you are still in possession of the Certify key and is more convenient.
+When a Subkey expires, it can either be renewed or replaced. Both actions require access to the Certify key.
 
-Replacing keys, on the other hand, is less convenient but more secure: the new Subkeys will **not** be able to decrypt previous messages, authenticate with SSH, etc. Contacts will need to receive the updated public key and any encrypted secrets need to be decrypted and re-encrypted to new Subkeys to be usable. This process is functionally equivalent to "losing" the YubiKey and provisioning a new one. However, you will always be able to decrypt previous messages using the offline encrypted backup of the original keys.
+- Renewing Subkeys by updating expiration dates indicates you are still in possession of the Certify key and is more convenient.
 
-Neither rotation method is superior and it's up to personal philosophy on identity management and individual threat model to decide which one to use, or whether to expire Subkeys at all. Ideally, Subkeys would be ephemeral: used only once for each encryption, signing and authentication event, however in practice that is not really feasible nor worthwhile with YubiKey. Advanced users may want to dedicate an offline device for more frequent key rotations and ease of provisioning.
+- Replacing keys, on the other hand, is less convenient but more secure: the new Subkeys will **not** be able to decrypt previous messages, authenticate with SSH, etc. Contacts will need to receive the updated public key and any encrypted secrets need to be decrypted and re-encrypted to new Subkeys to be usable. This process is functionally equivalent to "losing" the YubiKey and provisioning a new one. However, you will always be able to decrypt previous messages using the encrypted backup of the original keys.
+
+Neither rotation method is superior and it's up to personal philosophy on identity management and individual threat model to decide which one to use, or whether to expire Subkeys at all. Ideally, Subkeys would be ephemeral: used only once for each unique encryption, signing and authentication event, however in practice that is not really feasible nor worthwhile with YubiKey. Advanced users may want to dedicate an air-gapped machine for more frequent rotations and ease of provisioning key materials.
 
 ## Setup environment
 
@@ -1961,7 +1969,7 @@ mmcblk0: mmc0:a001 SS16G 14.8 GiB (ro)
 mmcblk0: p1 p2
 ```
 
-Decrypt and mount the offline volume:
+Decrypt and mount the encrypted volume:
 
 ```console
 sudo cryptsetup luksOpen /dev/mmcblk0p1 secret
@@ -2057,7 +2065,7 @@ ssb*  rsa4096/0x3F29127E79649A3D
 [ultimate] (1). Dr Duh <doc@duh.to>
 ```
 
-Then, use the `expire` command to set a new expiration date.  (Despite the name, this will not cause currently valid keys to become expired.)
+Then, use the `expire` command to set a new expiration date. This will **not** cause currently valid keys to become expired.
 
 ```console
 gpg> expire
@@ -2070,7 +2078,8 @@ Please specify how long the key should be valid.
       <n>y = key expires in n years
 Key is valid for? (0)
 ```
-Follow these prompts to set a new expiration date, then `save` to save your changes.
+
+Follow these prompts to set a new expiration date, then `save`
 
 Next, [export the public key](#export-public-keys):
 
@@ -2078,7 +2087,7 @@ Next, [export the public key](#export-public-keys):
 gpg --armor --export $KEYID > gpg-$KEYID-$(date +%F).asc
 ```
 
-Transfer that public key to the computer from which you use your GPG key, and then import it with:
+Transfer the public key to the computer from which you use your GPG key, and then import it with:
 
 ```console
 gpg --import gpg-0x*.asc
@@ -2096,7 +2105,7 @@ and import the newly updated key on any computer where you wish to use it (it wi
 gpg --recv $KEYID
 ```
 
-This will extend the validity of your GPG key and will allow you to use it for SSH authorization.  Note that you do _not_ need to update the SSH public key located on remote servers.
+This will extend the validity of the GPG key and will allow you to use it for SSH authorization. Note that you do **not** need to update the SSH public key located on remote servers.
 
 ## Rotating keys
 
@@ -2217,7 +2226,7 @@ export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
 gpgconf --launch gpg-agent
 ```
 
-If you use fish, the correct lines for your `config.fish` would look like this (consider putting them into the `is-interactive` block depending on your use case):
+For fish, `config.fish` would look like this (consider putting them into the `is-interactive` block):
 
 ```fish
 set -x GPG_TTY (tty)
@@ -2225,7 +2234,7 @@ set -x SSH_AUTH_SOCK (gpgconf --list-dirs agent-ssh-socket)
 gpgconf --launch gpg-agent
 ```
 
-Note that if you use `ForwardAgent` for ssh-agent forwarding, `SSH_AUTH_SOCK` only needs to be set on the *local* laptop (workstation), where the YubiKey is plugged in.  On the *remote* server that we SSH into, `ssh` will automatically set `SSH_AUTH_SOCK` to something like `/tmp/ssh-mXzCzYT2Np/agent.7541` when we connect.  We therefore do **NOT** manually set `SSH_AUTH_SOCK` on the server - doing so would break [SSH Agent Forwarding](#remote-machines-ssh-agent-forwarding).
+Note that if you use `ForwardAgent` for ssh-agent forwarding, `SSH_AUTH_SOCK` only needs to be set on the *local* laptop (workstation), where the YubiKey is plugged in. On the *remote* server, `ssh` will automatically set `SSH_AUTH_SOCK` to something like `/tmp/ssh-mXzCzYT2Np/agent.7541` upon connection. Do **not** manually set `SSH_AUTH_SOCK` on the server - doing so would break [SSH Agent Forwarding](#remote-machines-ssh-agent-forwarding).
 
 If you use `S.gpg-agent.ssh` (see [SSH Agent Forwarding](#remote-machines-ssh-agent-forwarding) for more info), `SSH_AUTH_SOCK` should also be set on the *remote*. However, `GPG_TTY` should not be set on the *remote*, explanation specified in that section.
 
@@ -2310,7 +2319,7 @@ $ ssh-add -l
 2048 SHA256:... /Users/username/.ssh/id_rsa (RSA)
 ```
 
-Or to show the keys with MD5 fingerprints, as used by `gpg-connect-agent`'s `KEYINFO` and `DELETE_KEY` commands:
+To show the keys with MD5 fingerprints, as used by `gpg-connect-agent`'s `KEYINFO` and `DELETE_KEY` commands:
 
 ```console
 $ ssh-add -E md5 -l
@@ -2318,7 +2327,7 @@ $ ssh-add -E md5 -l
 2048 MD5:... /Users/username/.ssh/id_rsa (RSA)
 ```
 
-When using the key `pinentry` will be invoked to request the key's passphrase. The passphrase will be cached for up to 10 minutes idle time between uses, to a maximum of 2 hours.
+When using the key `pinentry` will be invoked to request the key passphrase. The passphrase will be cached for up to 10 idle minutes between uses, up to a maximum of 2 hours.
 
 ## Remote Machines (SSH Agent Forwarding)
 
@@ -2346,7 +2355,7 @@ You may use the command:
 $ gpgconf --list-dirs agent-ssh-socket
 ```
 
-Then in your `.ssh/config` add one sentence for that remote
+Edit `.ssh/config` to add the remote host:
 
 ```
 Host
@@ -2365,7 +2374,7 @@ Then in the *remote* you can type in command line or configure in the shell rc f
 export SSH_AUTH_SOCK="/run/user/$UID/gnupg/S.gpg-agent.ssh"
 ```
 
-After typing or sourcing your shell rc file, with `ssh-add -l` you should find your ssh public key now.
+After sourcing the shell rc file, `ssh-add -l` will return the correct public key.
 
 **Note** In this process no gpg-agent in the remote is involved, hence `gpg-agent.conf` in the remote is of no use. Also pinentry is invoked locally.
 
@@ -2388,17 +2397,19 @@ You should change the path according to `gpgconf --list-dirs agent-ssh-socket` o
 
 ## GitHub
 
-You can use YubiKey to sign GitHub commits and tags. It can also be used for GitHub SSH authentication, allowing you to push, pull, and commit without a password.
+YubiKey can be used to sign commits and tags, and authenticate SSH to GitHub.
 
-Login to GitHub and upload SSH and PGP public keys in Settings.
+Manage SSH and PGP keys in [Settings](https://github.com/settings/keys).
 
 To configure a signing key:
 
-	> git config --global user.signingkey $KEYID
+```console
+git config --global user.signingkey $KEYID
+```
 
-Make sure the user.email option matches the email address associated with the PGP identity.
+The `user.email` option must match the email address associated with the PGP identity.
 
-Now, to sign commits or tags simply use the `-S` option. GPG will automatically query YubiKey and prompt you for a PIN.
+To sign commits or tags, use the `-S` option. GPG will automatically query YubiKey and prompt for a PIN.
 
 To authenticate:
 
@@ -2430,14 +2441,16 @@ doas reboot
 
 ## Windows
 
-Windows can already have some virtual smartcard readers installed, like the one provided for Windows Hello. To ensure your YubiKey is the correct one used by scdaemon, you should add it to its configuration. You will need your device's full name. To find your device's full name, plug in your YubiKey and open PowerShell to run the following command:
+Windows can already have some virtual smartcard readers installed, like the one provided for Windows Hello. To ensure YubiKey is the correct one used by scdaemon, add it to its configuration.
+
+First, find YubiKey label using PowerShell:
 
 ``` powershell
 PS C:\WINDOWS\system32> Get-PnpDevice -Class SoftwareDevice | Where-Object {$_.FriendlyName -like "*YubiKey*"} | Select-Object -ExpandProperty FriendlyName
 Yubico YubiKey OTP+FIDO+CCID 0
 ```
 
-The name slightly differs according to the model. See [How to setup Signed Git Commits with a YubiKey NEO and GPG and Keybase on Windows (2018)](https://www.hanselman.com/blog/HowToSetupSignedGitCommitsWithAYubiKeyNEOAndGPGAndKeybaseOnWindows.aspx) for more information.
+See [How to setup Signed Git Commits with a YubiKey NEO and GPG and Keybase on Windows (2018)](https://www.hanselman.com/blog/HowToSetupSignedGitCommitsWithAYubiKeyNEOAndGPGAndKeybaseOnWindows.aspx) for more information.
 
 * Create or edit `%APPDATA%/gnupg/scdaemon.conf` to add:
 
@@ -2671,7 +2684,7 @@ Host third
 
 You should change the path according to `gpgconf --list-dirs agent-socket` on *remote* and *third*.
 
-**Note** On *local* you have `S.gpg-agent.extra` whereas on *remote* and *third*, you only have `S.gpg-agent`.
+**Note** On *local* you have `S.gpg-agent.extra` whereas on *remote* and *third*, you only have `S.gpg-agent`
 
 # Using Multiple Keys
 
@@ -2707,7 +2720,7 @@ See discussion in Issues [#19](https://github.com/drduh/YubiKey-Guide/issues/19)
 
 To add an identity after creating and backing up a YubiKey, first add the identity to the Certify key, and then reset YubiKey and use `keytocard` to move the Subkeys to the card again.
 
-To add another identity to your GPG key, follow the same process as generating keys: boot to a secure environment, install required software and disconnect networking.
+Follow the same process as generating keys: boot to a secure environment, install required software and disconnect networking.
 
 Connect the portable storage device with the Certify key and identify the disk label:
 
@@ -2718,7 +2731,7 @@ mmcblk0: mmc0:a001 SS16G 14.8 GiB (ro)
 mmcblk0: p1 p2
 ```
 
-Decrypt and mount the offline volume:
+Decrypt and mount the encrypted volume:
 
 ```console
 sudo cryptsetup luksOpen /dev/mmcblk0p1 secret
@@ -2726,7 +2739,7 @@ sudo cryptsetup luksOpen /dev/mmcblk0p1 secret
 sudo mount /dev/mapper/secret /mnt/encrypted-storage
 ```
 
-Restore your backup to a temporary directory:
+Restore the backup to a temporary directory:
 
 ```console
 export GNUPGHOME=$(mktemp -d -t gnupg_$(date +%Y%m%d%H%M)_XXX)
@@ -2742,11 +2755,9 @@ $ KEYID=<your keyID>
 $ gpg --expert --edit-key $KEYID
 
 gpg> adduid
-Real name: «your name»
-Email address: «user@domain.tld»
-Comment: «something»
-You selected this USER-ID:
-      "«your name» («something») <«user@domain.tld»>"
+Real name:
+Email address:
+Comment:
 
 Change (N)ame, (C)omment, (E)mail or (O)kay/(Q)uit? O
 
@@ -2776,7 +2787,7 @@ gpg --armor --export-secret-keys $KEYID > $GNUPGHOME/certify.key
 gpg --armor --export-secret-subkeys $KEYID > $GNUPGHOME/subkeys.key
 ```
 
-And your public key:
+And the public key:
 
 ```console
 gpg --armor --export $KEYID | sudo tee /mnt/public/gpg-$KEYID-$(date +%F).asc
@@ -2792,7 +2803,7 @@ gpg -o \path\to\dir\subkeys.gpg --armor --export-secret-subkeys $KEYID
 gpg -o \path\to\dir\pubkey.gpg --armor --export $KEYID
 ```
 
-Copy the **new** temporary working directory to encrypted offline storage, which should still be mounted:
+Copy the **new** temporary working directory to encrypted storage, which should still be mounted:
 
 ```console
 sudo cp -avi $GNUPGHOME /mnt/encrypted-storage
@@ -2806,25 +2817,25 @@ sudo umount /mnt/encrypted-storage
 sudo cryptsetup luksClose /dev/mapper/secret
 ```
 
-## Updating your YubiKey
+## Updating YubiKey
 
-Now that your keys have been updated with your new identity, you have to move them onto your YubiKey. To do so, you need to first [reset](#reset) the OpenPGP applet on your YubiKey, and then follow the steps to [configure your smartcard](#configure-smartcard) again.
+Now that keys have been updated with the new identity, they will need to be loaded to YubiKey.
 
-Now you can [transfer the keys](#transfer-keys) to your YubiKey. Once you've done so, be sure to reboot or securely erase the GPG temporary working directory, and `unset GNUPGHOME`.
+First, [Reset](#reset) the OpenPGP applet, then follow the steps to [Configure Smartcard](#configure-smartcard) again.
 
-Finally, re-import the public key, as described in the [using keys](#using-keys) section.
+Next, [Transfer Keys](#transfer-keys) and reboot or securely erase the GPG temporary working directory.
 
-Run `gpg -K` to confirm that your new identity is listed.
+Finally, re-import the public key, as described in [Using Keys](#using-keys).
+
+Use `gpg -K` to verify the identity is listed.
 
 # Require touch
 
 **Note** This is not possible on YubiKey NEO.
 
-By default, YubiKey will perform encryption, signing and authentication operations without requiring any action from the user, after the key is plugged in and first unlocked with the PIN.
+By default, YubiKey will perform encryption, signing and authentication operations without requiring any action from the user after the key is plugged in and unlocked once with the PIN.
 
 To require a touch for each key operation, install [YubiKey Manager](https://developers.yubico.com/yubikey-manager/) and recall the Admin PIN:
-
-**Note** Older versions of YubiKey Manager use `touch` instead of `set-touch` in the following commands.
 
 Authentication:
 
@@ -2845,6 +2856,8 @@ ykman openpgp keys set-touch dec on
 ```
 
 **Note** Versions of YubiKey Manager before 5.1.0 use `enc` instead of `dec` for encryption.
+
+**Note** Older versions of YubiKey Manager use `touch` instead of `set-touch`
 
 Depending on how the YubiKey is going to be used, you may want to look at the policy options for each of these and adjust the above commands accordingly. They can be viewed with the following command:
 
@@ -2927,7 +2940,7 @@ To enable GnuPG support, one can just use the config file `gpg.rc` provided by m
 
 # Reset
 
-If PIN attempts are exceeded, the card is locked and must be [reset](https://developers.yubico.com/ykneo-openpgp/ResetApplet.html) and set up again using the encrypted backup.
+If PIN attempts are exceeded, the YubiKey is locked and must be [reset](https://developers.yubico.com/ykneo-openpgp/ResetApplet.html) and set up again using the encrypted backup.
 
 Copy the following script to a file and run `gpg-connect-agent -r $file` to lock and terminate the card. Then re-insert YubiKey to reset.
 
@@ -2961,15 +2974,19 @@ Admin PIN:   12345678
 
 ## Recovery after reset
 
-To reinstate YubiKey from the Certify key backup (such as the one stored on an encrypted USB described in [Backup](#backup)), follow [Rotating keys](#rotating-keys) to setup the environment, then [Configure Smartcard](#configure-smartcard).
+To reinstate YubiKey from the Certify key backup (such as the one on encrypted portable storage described in [Backup](#backup)), follow [Rotating keys](#rotating-keys) to setup the environment, then [Configure Smartcard](#configure-smartcard).
 
 # Notes
 
 - YubiKey has two configurations: one invoked with a short press, and the other with a long press. By default, the short-press mode is configured for HID OTP - a brief touch will emit an OTP string starting with `cccccccc`. If you rarely use the OTP mode, you can swap it to the second configuration via the YubiKey Personalization tool. If you *never* use OTP, you can disable it entirely using the [YubiKey Manager](https://developers.yubico.com/yubikey-manager) application (note, this not the similarly named older YubiKey NEO Manager). The command to disable OTP with ykman is `ykman config usb -d OTP`.
+
 - Programming YubiKey for GPG keys still lets you use its other configurations - [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor), [OTP](https://www.yubico.com/faq/what-is-a-one-time-password-otp/) and [static password](https://www.yubico.com/products/services-software/personalization-tools/static-password/) modes, for example.
+
 - Setting an expiry essentially forces you to manage your subkeys and announces to the rest of the world that you are doing so. Setting an expiry on a primary key is ineffective for protecting the key from loss - whoever has the primary key can simply extend its expiry period. Revocation certificates are [better suited](https://security.stackexchange.com/questions/14718/does-openpgp-key-expiration-add-to-security/79386#79386) for this purpose. It may be appropriate for your use case to set expiry dates on subkeys.
-- To switch between two or more identities on different keys - unplug the first key and restart gpg-agent, ssh-agent and pinentry with `pkill gpg-agent ; pkill ssh-agent ; pkill pinentry ; eval $(gpg-agent --daemon --enable-ssh-support)`, then plug in the other key and run `gpg-connect-agent updatestartuptty /bye` - then it should be ready for use.
-- To use YubiKey on multiple computers, import the public keys on the additional ones. Confirm gpg can see the card via `gpg --card-status`, then trust the import public keys ultimately. `gpg --list-secret-keys` should show the correct and trusted key.
+
+- To switch between two or more identities on different keys - unplug the first YubiKey and restart gpg-agent, ssh-agent and pinentry with `pkill gpg-agent ; pkill ssh-agent ; pkill pinentry ; eval $(gpg-agent --daemon --enable-ssh-support)`, then plug in the other key and run `gpg-connect-agent updatestartuptty /bye` - then it should be ready for use.
+
+- To use YubiKey on multiple computers, import the corresponding public keys on them. Confirm gpg can see the card via `gpg --card-status`, then trust the import public keys ultimately. `gpg --list-secret-keys` should show the correct and trusted key.
 
 # Troubleshooting
 
@@ -3020,7 +3037,7 @@ gpg: 0x0000000000000000: There is no assurance this key belongs to the named use
 gpg: [stdin]: encryption failed: Unusable public key
 ```
 
-- If you receive the error, `gpg: 0x0000000000000000: skipped: Unusable public key`, `signing failed: Unusable secret key`, or `encryption failed: Unusable public key` the subkey may be expired and can no longer be used to encrypt nor sign messages. It can still be used to decrypt and authenticate, however.
+- If you receive the error, `gpg: 0x0000000000000000: skipped: Unusable public key`, `signing failed: Unusable secret key`, or `encryption failed: Unusable public key` the Subkey may be expired and can no longer be used to encrypt nor sign messages. It can still be used to decrypt and authenticate, however.
 
 - If you lost your GPG public key, follow [this guide](https://www.nicksherlock.com/2021/08/recovering-lost-gpg-public-keys-from-your-yubikey/) to recover it from YubiKey.
 
@@ -3053,7 +3070,7 @@ EOF
 
 Keys can also be generated using template files and the `batch` parameter - see [GnuPG documentation](https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html).
 
-Start from the [gen-params-rsa4096](contrib/gen-params-rsa4096) template. If you're using GnuPG v2.1.7 or newer, you can also use the ([gen-params-ed25519](contrib/gen-params-ed25519) template. These templates will not set the Certify key to expire - see [Note #3](#notes).
+Use the example [gen-params-rsa4096](contrib/gen-params-rsa4096) or ([gen-params-ed25519](contrib/gen-params-ed25519) template (the latter requires GnuPG v2.1.7).
 
 Generate the Certify key:
 
@@ -3079,11 +3096,9 @@ pub   rsa4096/0xFF3E7D88647EBCDB 2021-08-22 [C]
 uid                   [ultimate] Dr Duh <doc@duh.to>
 ```
 
-The key fingerprint (`011C E16B D45B 27A5 5BA8 776D FF3E 7D88 647E BCDB`) will be used to create the three subkeys for signing, authentication and encryption.
+The fingerprint (`011C E16B D45B 27A5 5BA8 776D FF3E 7D88 647E BCDB`) is used to create the three Subkeys for signing, authentication and encryption.
 
-Now create three Subkeys for signing, authentication and encryption. Use a 1 year expiration for Subkeys - they can be renewed using the Certify key, see [rotating keys](#rotating-keys).
-
-We will use the the quick key manipulation interface of GNUPG (with `--quick-add-key`), see [the documentation](https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html#Unattended-GPG-key-generation).
+Use a one or several year expiration for Subkeys - they can be renewed using the Certify key, see [rotating keys](#rotating-keys).
 
 Create a [signing subkey](https://stackoverflow.com/questions/5421107/can-rsa-be-both-used-as-encryption-and-signature/5432623#5432623):
 

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ The primary key to generate is the Certify key, which will be used to issue Subk
 
 The Certify key should be kept offline at all times and only accessed from a secure environment to revoke or issue Subkeys. Keys can also be generated on the YubiKey itself to avoid duplication, however for usability and durability reasons this guide recommends against doing so.
 
-Generate a passphrase which will be needed throughout the guide to create and export Subkeys. The passphrase should be memorized or written down in a secure place separate from the backup storage disk.
+Generate a passphrase which will be needed throughout the guide to create and export Subkeys. The passphrase should be memorized or written down in a secure location, ideally separate from the portable storage device used for key material.
 
 The passphrase is recommended to consist of only upper case letters and numbers for improved readability.
 
@@ -475,7 +475,7 @@ Generate the Certify key with GnuPG:
 gpg --expert --full-generate-key
 ```
 
-Select `(8) RSA (set your own capabilities)`, then `E` and `S` deselect Encrypt and Sign actions and only the Certify capability remains:
+Select `(8) RSA (set your own capabilities)`, then type `E` and `S` deselect Encrypt and Sign actions and only the Certify capability remains:
 
 ```console
 Please select what kind of key you want:
@@ -521,7 +521,7 @@ Current allowed actions: Certify
    (Q) Finished
 ```
 
-Select `Q` then `4096` as the keysize.
+Type `Q` then `4096` as the requested keysize.
 
 Do **not** set the Certify key to expire (see [Note #3](#notes)).
 
@@ -541,7 +541,7 @@ Key does not expire at all
 Is this correct? (y/N) y
 ```
 
-Input any name and email address (it doesn't have to be valid) - Comment is optional:
+Input any value for Real name and Email address; Comment is optional:
 
 ```console
 GnuPG needs to construct a user ID to identify your key.
@@ -575,7 +575,7 @@ export KEYID=0xF0F2CFEB04341FB5
 
 # Sign with existing key
 
-**Optional** Existing PGP keys may be used to sign new ones to prove control.
+**Optional** Existing PGP keys may be used to sign new ones to prove ownership.
 
 Export the existing key to move it to the working keyring:
 
@@ -599,11 +599,11 @@ gpg --expert --edit-key $KEYID
 
 RSA with 4096-bit key length is recommended.
 
-Subkeys are recommended to have one or several year expirations. They must be renewed using the Certify key. See [rotating keys](#rotating-keys).
+Subkeys are recommended to have one or several year expirations. They must be renewed using the Certify key - see [Rotating keys](#rotating-keys).
 
 ## Signing
 
-Create a [signing key](https://stackoverflow.com/questions/5421107/can-rsa-be-both-used-as-encryption-and-signature/5432623#5432623) by selecting `addkey` then the `(4) RSA (sign only)` option:
+Create a [signing key](https://stackoverflow.com/questions/5421107/can-rsa-be-both-used-as-encryption-and-signature/5432623#5432623) by typing `addkey` then select the `(4) RSA (sign only)` option:
 
 ```console
 gpg> addkey
@@ -647,9 +647,40 @@ ssb  rsa4096/0xB3CD10E502E19637
 
 ## Encryption
 
-Next, create an [encryption key](https://www.cs.cornell.edu/courses/cs5430/2015sp/notes/rsa_sign_vs_dec.php) by selecting `addkey` then the `(6) RSA (encrypt only)` option.
+Next, create an [encryption key](https://www.cs.cornell.edu/courses/cs5430/2015sp/notes/rsa_sign_vs_dec.php) by typing `addkey` then select the `(6) RSA (encrypt only)` option:
 
 ```console
+gpg> addkey
+Please select what kind of key you want:
+   (3) DSA (sign only)
+   (4) RSA (sign only)
+   (5) Elgamal (encrypt only)
+   (6) RSA (encrypt only)
+   (7) DSA (set your own capabilities)
+   (8) RSA (set your own capabilities)
+  (10) ECC (sign only)
+  (11) ECC (set your own capabilities)
+  (12) ECC (encrypt only)
+  (13) Existing key
+  (14) Existing key from card
+Your selection? 6
+RSA keys may be between 1024 and 4096 bits long.
+What keysize do you want? (3072) 4096
+Requested keysize is 4096 bits
+Please specify how long the key should be valid.
+         0 = key does not expire
+      <n>  = key expires in n days
+      <n>w = key expires in n weeks
+      <n>m = key expires in n months
+      <n>y = key expires in n years
+Key is valid for? (0) 2y
+Is this correct? (y/N) y
+Really create? (y/N) y
+We need to generate a lot of random bytes. It is a good idea to perform
+some other action (type on the keyboard, move the mouse, utilize the
+disks) during the prime generation; this gives the random number
+generator a better chance to gain enough entropy.
+
 sec  rsa4096/0xF0F2CFEB04341FB5
      created: 2024-01-01  expires: never       usage: C
      trust: ultimate      validity: ultimate
@@ -662,9 +693,7 @@ ssb  rsa4096/0x30CBE8C4B085B9F7
 
 ## Authentication
 
-Finally, create an [authentication key](https://superuser.com/questions/390265/what-is-a-gpg-with-authenticate-capability-used-for).
-
-Select `addkey` then the `(8) RSA (set your own capabilities)` option.
+Finally, create an [authentication key](https://superuser.com/questions/390265/what-is-a-gpg-with-authenticate-capability-used-for) by typing `addkey` then select the `(8) RSA (set your own capabilities)` option.
 
 Toggle the required capabilities with `S`, `E` and `A` until `Authenticate` is the only selected action:
 
@@ -1287,9 +1316,9 @@ gpg/card> quit
 
 # Transfer keys
 
-**Important** Transferring keys to YubiKey is a one-way/destructive operation. Verify backups were made before proceeding. `keytocard` converts the local, on-disk key into a stub, which means the on-disk copy is no longer usable to transfer to subsequent YubiKeys.
+**Important** Transferring keys to YubiKey is a one-way operation. Verify backups were made before proceeding. `keytocard` converts the local, on-disk key into a stub, which means the on-disk copy is no longer usable to transfer to subsequent YubiKeys.
 
-Previous GnuPG versions required the `toggle` command before selecting keys. The currently selected key(s) are indicated with an `*`. When moving keys only one key should be selected at a time.
+The currently selected key(s) are indicated with an `*`. When transferring keys, only one subkey should be selected at a time.
 
 ```console
 gpg --edit-key $KEYID
@@ -1297,12 +1326,23 @@ gpg --edit-key $KEYID
 
 ## Signing
 
-**Important** You will be prompted for the Certify key passphrase and Admin PIN.
+The Certify key passphrase and Admin PIN are required for this step.
 
 Select and transfer the signature key - `*` will appear next to the selected subkey (`ssb*`):
 
 ```console
 gpg> key 1
+
+sec  rsa4096/0xF0F2CFEB04341FB5
+     created: 2024-01-01  expires: never       usage: C
+     trust: ultimate      validity: ultimate
+ssb* rsa4096/0xB3CD10E502E19637
+     created: 2024-01-01  expires: 2026-01-01  usage: S
+ssb  rsa4096/0x30CBE8C4B085B9F7
+     created: 2024-01-01  expires: 2026-01-01  usage: E
+ssb  rsa4096/0xAD9E24E1B8CB9600
+     created: 2024-01-01  expires: 2026-01-01  usage: A
+[ultimate] (1). YubiKey User <yubikey@example>
 
 gpg> keytocard
 Please select where to store the key:
@@ -1313,12 +1353,23 @@ Your selection? 1
 
 ## Encryption
 
-Type `key 1` again to de-select and `key 2` to select the next key:
+Type `key 1` again to deselect the first key and `key 2` to select the next key:
 
 ```console
 gpg> key 1
 
 gpg> key 2
+
+sec  rsa4096/0xF0F2CFEB04341FB5
+     created: 2024-01-01  expires: never       usage: C
+     trust: ultimate      validity: ultimate
+ssb  rsa4096/0xB3CD10E502E19637
+     created: 2024-01-01  expires: 2026-01-01  usage: S
+ssb* rsa4096/0x30CBE8C4B085B9F7
+     created: 2024-01-01  expires: 2026-01-01  usage: E
+ssb  rsa4096/0xAD9E24E1B8CB9600
+     created: 2024-01-01  expires: 2026-01-01  usage: A
+[ultimate] (1). YubiKey User <yubikey@example>
 
 gpg> keytocard
 Please select where to store the key:
@@ -1328,12 +1379,23 @@ Your selection? 2
 
 ## Authentication
 
-Type `key 2` again to deselect and `key 3` to select the last key:
+Type `key 2` again to deselect the second key and `key 3` to select the last key:
 
 ```console
 gpg> key 2
 
 gpg> key 3
+
+sec  rsa4096/0xF0F2CFEB04341FB5
+     created: 2024-01-01  expires: never       usage: C
+     trust: ultimate      validity: ultimate
+ssb  rsa4096/0xB3CD10E502E19637
+     created: 2024-01-01  expires: 2026-01-01  usage: S
+ssb  rsa4096/0x30CBE8C4B085B9F7
+     created: 2024-01-01  expires: 2026-01-01  usage: E
+ssb* rsa4096/0xAD9E24E1B8CB9600
+     created: 2024-01-01  expires: 2026-01-01  usage: A
+[ultimate] (1). YubiKey User <yubikey@example>
 
 gpg> keytocard
 Please select where to store the key:
@@ -1561,7 +1623,7 @@ export KEYID=0xF0F2CFEB04341FB5
 gpg --edit-key $KEYID
 ```
 
-Assign ultimate trust by selecting `trust` and `5`:
+Assign ultimate trust by tying `trust` and selecting option `5`:
 
 ```console
 gpg> trust
@@ -1752,11 +1814,34 @@ gpg> key 1
 gpg> key 2
 
 gpg> key 3
+
+sec  rsa4096/0xF0F2CFEB04341FB5
+     created: 2024-01-01  expires: never       usage: C
+     trust: ultimate      validity: ultimate
+ssb* rsa4096/0xB3CD10E502E19637
+     created: 2024-01-01  expires: 2026-01-01  usage: S
+ssb* rsa4096/0x30CBE8C4B085B9F7
+     created: 2024-01-01  expires: 2026-01-01  usage: E
+ssb* rsa4096/0xAD9E24E1B8CB9600
+     created: 2024-01-01  expires: 2026-01-01  usage: A
+[ultimate] (1). YubiKey User <yubikey@example>
 ```
 
 Use `expire` to configure the expiration date. This will **not** expire valid keys.
 
-Follow the prompt to set the expiration date, then `save`
+```console
+gpg> expire
+Changing expiration time for a subkey.
+Please specify how long the key should be valid.
+         0 = key does not expire
+      <n>  = key expires in n days
+      <n>w = key expires in n weeks
+      <n>m = key expires in n months
+      <n>y = key expires in n years
+Key is valid for? (0)
+```
+
+Set the expiration date, then `save`
 
 Next, [Export public keys](#export-public-keys):
 
@@ -1930,7 +2015,7 @@ By default, SSH attempts to use all the identities available via the agent. It's
 
 The argument provided to `IdentityFile` is traditionally the path to the _private_ key file (for example `IdentityFile ~/.ssh/id_rsa`). For YubiKey, `IdentityFile` must point to the _public_ key file, and `ssh` will select the appropriate private key from those available via ssh-agent. To prevent `ssh` from trying all keys in the agent, use `IdentitiesOnly yes` along with one or more `-i` or `IdentityFile` options for the target host.
 
-To reiterate, with `IdentitiesOnly yes`, `ssh` will not enumerate public keys loaded into `ssh-agent` or `gpg-agent`. This means `publickey` authentication will not proceed unless explicitly named by `ssh -i [identity_file]` or in `.ssh/config` on a per-host basis.
+To reiterate, with `IdentitiesOnly yes`, `ssh` will not enumerate public keys loaded into `ssh-agent` or `gpg-agent`. This means public-key authentication will not proceed unless explicitly named by `ssh -i [identity_file]` or in `.ssh/config` on a per-host basis.
 
 In the case of YubiKey usage, to extract the public key from the ssh agent:
 
@@ -2431,34 +2516,19 @@ export GNUPGHOME=$(mktemp -d -t gnupg_$(date +%Y%m%d%H%M)_XXX)
 cp -avi /mnt/encrypted-storage/tmp.XXX/* $GNUPGHOME
 ```
 
-Edit the Certify key to add the new identity:
+Edit the Certify key:
 
 ```console
-$ KEYID=<your keyID>
+gpg --expert --edit-key $KEYID
+```
 
-$ gpg --expert --edit-key $KEYID
+Add the identity and set ultimate trust:
 
+```console
 gpg> adduid
-Real name:
-Email address:
-Comment:
-
-Change (N)ame, (C)omment, (E)mail or (O)kay/(Q)uit? O
 
 gpg> trust
-
-Please decide how far you trust this user to correctly verify other users' keys
-(by looking at passports, checking fingerprints from different sources, etc.)
-
-  1 = I don't know or won't say
-  2 = I do NOT trust
-  3 = I trust marginally
-  4 = I trust fully
-  5 = I trust ultimately
-  m = back to the main menu
-
 Your decision? 5
-Do you really want to set this key to ultimate trust? (y/N) y
 
 gpg> save
 ```
@@ -2477,7 +2547,7 @@ Export the public key:
 gpg --armor --export $KEYID | sudo tee /mnt/public/gpg-$KEYID-$(date +%F).asc
 ```
 
-As before, on Windows, note that using any extension other than `.gpg` or attempting IO redirection to a file will garble the secret key, making it impossible to import it again at a later date:
+**Note** On Windows, using an extension other than `.gpg` or attempting IO redirection to a file will result in a nonfunctional private key.
 
 ```console
 gpg -o \path\to\dir\certify.gpg --armor --export-secret-keys $KEYID
@@ -2487,7 +2557,7 @@ gpg -o \path\to\dir\subkeys.gpg --armor --export-secret-subkeys $KEYID
 gpg -o \path\to\dir\pubkey.gpg --armor --export $KEYID
 ```
 
-Copy the **new** temporary working directory to encrypted storage, which should still be mounted:
+Copy the **new** working directory to encrypted storage, which should still be mounted:
 
 ```console
 sudo cp -avi $GNUPGHOME /mnt/encrypted-storage
@@ -2772,7 +2842,7 @@ Verify results:
 gpg --list-key
 ```
 
-The fingerprint is used to create the three Subkeys for signing, authentication and encryption.
+The fingerprint is used to create the three Subkeys for encryption, signing and authentication operations.
 
 Use a one or several year expiration for Subkeys - they can be renewed using the Certify key, see [rotating keys](#rotating-keys).
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ sudo apt -y install \
     yubikey-personalization
 ```
 
-**Note** `hopenpgp-tools` is no longer part of the latest Debian stable package repositories. To install it, go to [https://packages.debian.org/sid/hopenpgp-tools](https://packages.debian.org/sid/hopenpgp-tools) to select your architecture (likely `amd64`) and then an ftp server.
+**Note** `hopenpgp-tools` is no longer part of the latest Debian stable package repositories. To install it, go to [https://packages.debian.org/sid/hopenpgp-tools](https://packages.debian.org/sid/hopenpgp-tools) to select the correct architecture (likely `amd64`) and then an ftp server.
 
 Edit `/etc/apt/sources.list` and add the ftp server:
 
@@ -998,7 +998,7 @@ sudo cp -avi $GNUPGHOME /mnt/encrypted-storage/
 sudo cp onerng_3.7-1_all.deb /mnt/encrypted-storage/
 ```
 
-**Note** If you plan on setting up multiple keys, keep the backup mounted or remember to terminate the gpg process before [saving](https://lists.gnupg.org/pipermail/gnupg-users/2016-July/056353.html).
+**Note** To set up multiple keys, keep the backup mounted or remember to terminate the GnuPG process before [saving](https://lists.gnupg.org/pipermail/gnupg-users/2016-July/056353.html).
 
 Unmount, close and disconnect the encrypted volume:
 
@@ -1094,7 +1094,7 @@ See [OpenBSD FAQ#14](https://www.openbsd.org/faq/faq14.html#softraidCrypto) for 
 
 # Export public keys
 
-**Important** Without the *public* key, you will **not** be able to use GnuPG to encrypt, decrypt, nor sign messages. However, you will still be able to use YubiKey for SSH authentication.
+**Important** Without the *public* key, it will **not** be possible to use GnuPG to encrypt, decrypt, nor sign messages. However, YubiKey may still be used for SSH authentication.
 
 Create another partition on the portable storage device to store the public key, or reconnect networking and upload to a key server.
 
@@ -1674,7 +1674,7 @@ ssb>  rsa4096/0xAD9E24E1B8CB9600  created: 2024-01-01  expires: 2026-01-01
 
 `sec#` indicates the corresponding key is not available.
 
-**Note** If you see `General key info..: [none]` in the output instead - go back and import the public key using the previous step.
+**Note** If `General key info..: [none]` appears in the output instead - go back and import the public key using the previous step.
 
 Encrypt a message to yourself (useful for storing credentials):
 
@@ -1711,7 +1711,7 @@ Verify the signature:
 
 ```console
 $ gpg --verify signed.txt
-gpg: Signature made Mon 01 Jan 2024 12:00:00 PM PST
+gpg: Signature made Mon 01 Jan 2024 12:00:00 PM UTC
 gpg:                using RSA key CF5A305B808B7A0F230DA064B3CD10E502E19637
 gpg: Good signature from "YubiKey User <yubikey@example>" [ultimate]
 Primary key fingerprint: 4E2C 1FA3 372C BA96 A06A  C34A F0F2 CFEB 0434 1FB5
@@ -1749,7 +1749,7 @@ PGP does not provide [forward secrecy](https://en.wikipedia.org/wiki/Forward_sec
 
 When a Subkey expires, it can either be renewed or replaced. Both actions require access to the Certify key.
 
-- Renewing Subkeys by updating expiration dates indicates you are still in possession of the Certify key and is more convenient.
+- Renewing Subkeys by updating expiration indicates continued possession of the Certify key and is more convenient.
 
 - Replacing Subkeys is less convenient but potentially more secure: the new Subkeys will **not** be able to decrypt previous messages, authenticate with SSH, etc. Contacts will need to receive the updated public key and any encrypted secrets need to be decrypted and re-encrypted to new Subkeys to be usable. This process is functionally equivalent to losing the YubiKey and provisioning a new one.
 
@@ -1892,8 +1892,7 @@ sudo cp -avi $GNUPGHOME /mnt/encrypted-storage
 There should now be at least two versions of the Certify and Subkeys:
 
 ```console
-$ ls /mnt/encrypted-storage
-lost+found  tmp.ykhTOGjR36  tmp.2gyGnyCiHs
+ls /mnt/encrypted-storage
 ```
 
 Unmount and close the encrypted volume:
@@ -1948,7 +1947,7 @@ Use `showpref` to verify notions were correctly added.
 
 When importing the key to `gpg-agent`, a passphrase will be required to encrypt within the key store. GnuPG can cache both passphrases with `cache-ttl` options. Note than when removing the old private key after importing to `gpg-agent`, keep the `.pub` key file around for use in specifying ssh identities (e.g. `ssh -i /path/to/identity.pub`).
 
-Probably the biggest thing missing from `gpg-agent`'s ssh agent support is being able to remove keys. `ssh-add -d/-D` have no effect. Instead, you need to use the `gpg-connect-agent` utility to lookup a key's keygrip, match that with the desired ssh key fingerprint (as an MD5) and then delete that keygrip. The [gnupg-users mailing list](https://lists.gnupg.org/pipermail/gnupg-users/2016-August/056499.html) has more information.
+Missing from `gpg-agent` ssh agent support is the ability to remove keys. `ssh-add -d/-D` have no effect. Instead, use the `gpg-connect-agent` utility to lookup a keygrip, match it with the desired ssh key fingerprint (as an MD5) and then delete that keygrip. The [gnupg-users mailing list](https://lists.gnupg.org/pipermail/gnupg-users/2016-August/056499.html) has more information.
 
 ## Create configuration
 
@@ -1962,9 +1961,9 @@ wget https://raw.githubusercontent.com/drduh/config/master/gpg-agent.conf
 
 **Important** The `cache-ttl` options do **not** apply when using YubiKey as a smart card, because the PIN is [cached by the smart card itself](https://dev.gnupg.org/T3362). To clear the PIN from cache (equivalent to `default-cache-ttl` and `max-cache-ttl`), unplug YubiKey, or set `forcesig` when editing the card to be prompted for the PIN each time.
 
-**Tip** Set `pinentry-program /usr/bin/pinentry-gnome3` for a GUI-based prompt. If the _pinentry_ graphical dialog doesn't show and you get this error: `sign_and_send_pubkey: signing failed: agent refused operation`, you may need to install the `dbus-user-session` package and restart the computer for the `dbus` user session to be fully inherited; this is because behind the scenes, `pinentry` complains about `No $DBUS_SESSION_BUS_ADDRESS found`, falls back to `curses` but doesn't find the expected `tty`.
+**Tip** Set `pinentry-program /usr/bin/pinentry-gnome3` for a GUI-based prompt. If the _pinentry_ graphical dialog doesn't show and this error appears: `sign_and_send_pubkey: signing failed: agent refused operation`, install the `dbus-user-session` package and restart the computer for the `dbus` user session to be fully inherited; this is because behind the scenes, `pinentry` complains about `No $DBUS_SESSION_BUS_ADDRESS found`, falls back to `curses` but doesn't find the expected `tty`.
 
-On macOS, use `brew install pinentry-mac` and set the program path to `pinentry-program /usr/local/bin/pinentry-mac` for Intel Macs, `/opt/homebrew/bin/pinentry-mac` for ARM/Apple Silicon Macs or `pinentry-program /usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac` if using MacGPG Suite. For the configuration to take effect you have to run `gpgconf --kill gpg-agent`.
+On macOS, use `brew install pinentry-mac` and set the program path to `pinentry-program /usr/local/bin/pinentry-mac` for Intel Macs, `/opt/homebrew/bin/pinentry-mac` for ARM/Apple Silicon Macs or `pinentry-program /usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac` if using MacGPG Suite. For the configuration to take effect, run `gpgconf --kill gpg-agent`
 
 ## Replace agents
 
@@ -1996,7 +1995,7 @@ gpgconf --launch gpg-agent
 
 When using `ForwardAgent` for ssh-agent forwarding, `SSH_AUTH_SOCK` only needs to be set on the *local* host, where YubiKey is connected. On the *remote* host, `ssh` will set `SSH_AUTH_SOCK` to something like `/tmp/ssh-mXzCzYT2Np/agent.7541` upon connection. Do **not** set `SSH_AUTH_SOCK` on the remote host - doing so will break [SSH Agent Forwarding](#remote-machines-ssh-agent-forwarding).
 
-If you use `S.gpg-agent.ssh` (see [SSH Agent Forwarding](#remote-machines-ssh-agent-forwarding) for more info), `SSH_AUTH_SOCK` should also be set on the *remote*. However, `GPG_TTY` should not be set on the *remote*, explanation specified in that section.
+For `S.gpg-agent.ssh` (see [SSH Agent Forwarding](#remote-machines-ssh-agent-forwarding) for more info), `SSH_AUTH_SOCK` should also be set on the *remote*. However, `GPG_TTY` should not be set on the *remote*, explanation specified in that section.
 
 ## Copy public key
 
@@ -2023,7 +2022,7 @@ In the case of YubiKey usage, to extract the public key from the ssh agent:
 ssh-add -L | grep "cardno:000605553211" > ~/.ssh/id_rsa_yubikey.pub
 ```
 
-Then you can explicitly associate this YubiKey-stored key for used with a host, `github.com` for example, as follows:
+Then explicitly associate this YubiKey-stored key for used with a host, `github.com` for example, as follows:
 
 ```console
 $ cat << EOF >> ~/.ssh/config
@@ -2100,8 +2099,6 @@ The latter one may be more insecure as raw socket is just forwarded (not like `S
 For example, tmux does not have environment variables such as `$SSH_AUTH_SOCK` when connecting to remote hosts and attaching an existing session. For each shell, find the socket and `export SSH_AUTH_SOCK=/tmp/ssh-agent-xxx/xxxx.socket`. However, with `S.gpg-agent.ssh` in a fixed place, it can be used as the ssh-agent in shell rc files.
 
 ### Use ssh-agent 
-
-In the above steps, you have successfully configured a local ssh-agent.
 
 You should now be able to use `ssh -A remote` on the _local_ host to log into _remote_ host, and should then be able to use YubiKey as if it were connected to the remote host. For example, using e.g. `ssh-add -l` on that remote host should show the public key from the YubiKey (note `cardno:`).  (If you don't want to have to remember to use `ssh -A`, you can use `ForwardAgent yes` in `~/.ssh/config`.  As a security best practice, always use `ForwardAgent yes` only for a single `Hostname`, never for all servers.)
 
@@ -2183,7 +2180,7 @@ git config --global gpg.program 'C:\Program Files (x86)\GnuPG\bin\gpg.exe'
 
 Update the repository URL to `git@github.com:USERNAME/repository` and any authenticated commands will be authorized by YubiKey.
 
-**Note** If you encounter the error `gpg: signing failed: No secret key` - run `gpg --card-status` with YubiKey plugged in and try the git command again.
+**Note** For the error `gpg: signing failed: No secret key` - run `gpg --card-status` with YubiKey plugged in and try the git command again.
 
 ## OpenBSD
 
@@ -2314,7 +2311,7 @@ Reload SSH daemon:
 sudo service sshd reload
 ```
 
-Unplug YubiKey, disconnect or reboot. Log back into Windows, open a WSL console and enter `ssh-add -l` - you should see nothing.
+Unplug YubiKey, disconnect or reboot. Log back into Windows, open a WSL console and enter `ssh-add -l` - no output should appear.
 
 Plug in YubiKey, enter the same command to display the ssh key.
 
@@ -2378,7 +2375,7 @@ Create `$HOME/Library/LaunchAgents/gnupg.gpg-agent-symlink.plist` with the follo
 launchctl load $HOME/Library/LaunchAgents/gnupg.gpg-agent-symlink.plist
 ```
 
-You will need to either reboot, or log out and log back in, in order to activate these changes.
+Reboot or log out and log back in to activate these changes.
 
 # Remote Machines (GPG Agent Forwarding)
 
@@ -2613,38 +2610,15 @@ ykman openpgp keys set-touch dec on
 
 **Note** Older versions of YubiKey Manager use `touch` instead of `set-touch`
 
-Depending on how the YubiKey is going to be used, you may want to look at the policy options for each of these and adjust the above commands accordingly. They can be viewed with the following command:
+To view and adjust policy options:
 
 ```
-$ ykman openpgp keys set-touch -h
-Usage: ykman openpgp keys set-touch [OPTIONS] KEY POLICY
-
-  Set the touch policy for OpenPGP keys.
-
-  The touch policy is used to require user interaction for all operations using the private key on the YubiKey. The touch policy is set
-  individually for each key slot. To see the current touch policy, run the "openpgp info" subcommand.
-
-  Touch policies:
-
-  Off (default)   no touch required
-  On              touch required
-  Fixed           touch required, can't be disabled without deleting the private key
-  Cached          touch required, cached for 15s after use
-  Cached-Fixed    touch required, cached for 15s after use, can't be disabled
-                  without deleting the private key
-
-  KEY     key slot to set (sig, dec, aut or att)
-  POLICY  touch policy to set (on, off, fixed, cached or cached-fixed)
-
-Options:
-  -a, --admin-pin TEXT  Admin PIN for OpenPGP
-  -f, --force           confirm the action without prompting
-  -h, --help            show this message and exit
+ykman openpgp keys set-touch -h
 ```
 
-If the YubiKey is going to be used within an email client that opens and verifies encrypted mail, `Cached` or `Cached-Fixed` may be desirable.
+If the YubiKey is going to be used within an email client which opens and verifies mail, `Cached` or `Cached-Fixed` may be desirable.
 
-YubiKey will blink when it is waiting for a touch. On Linux you can also use [yubikey-touch-detector](https://github.com/maximbaz/yubikey-touch-detector) to have an indicator or notification that YubiKey is waiting for a touch.
+YubiKey will blink when it is waiting for a touch. On Linux, [maximbaz/yubikey-touch-detector](https://github.com/maximbaz/yubikey-touch-detector) can be used to indicate YubiKey is waiting for a touch.
 
 # Email
 


### PR DESCRIPTION
- Standardize terminology (Certify key, Subkeys, portable storage device, etc.)
- Remove leading `$` from code blocks for easier copy-paste
- Attempt to simplify expiration/rotation instructions
- Improve grammar and style throughout
- Memorable strong passphrase instructions
- Focus backups on durability, still needs more emphasis
- Organize and prune links