### PR TITLE
update gpg --quick-add-key commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2712,16 +2712,17 @@ Verify the Certify key:
 gpg --list-key
 ```
 
-Export the Certify key ID and create the Subkeys:
+Export the Certify key ID, extract its fingerprint and create the Subkeys:
 
 ```console
 export KEYID=0xF0F2CFEB04341FB5
+KEYFPR=$(gpg --fingerprint "$KEYID" | grep -Eo '([0-9A-F][0-9A-F ]{49})' | head -n 1 | tr -d ' ')
 
-gpg --quick-add-key "$KEYID" rsa4096 sign 2y
+gpg --quick-add-key "$KEYFPR" rsa4096 sign 2y
 
-gpg --quick-add-key "$KEYID" rsa4096 encrypt 2y
+gpg --quick-add-key "$KEYFPR" rsa4096 encrypt 2y
 
-gpg --quick-add-key "$KEYID" rsa4096 auth 2y
+gpg --quick-add-key "$KEYFPR" rsa4096 auth 2y
 ```
 
 # Additional resources


### PR DESCRIPTION
`gpg --quick-add-key` seems to be only accepting fingerprints and rejecting key ID-s:

```
$ export KEYID=0x450944965A788EE4
$ gpg --quick-add-key "$KEYID" rsa4096 auth 2y
gpg: "0x450944965A788EE4" is not a fingerprint

```
so we should extract the fingerprint from the following:
```
$ gpg --fingerprint $KEYID
pub   rsa4096/0x450944965A788EE4 2024-03-04 [C]
      Key fingerprint = 6768 2AB6 06DF 7C9A 8BB6  C2D6 4509 4496 5A78 8EE4
uid                   [ultimate] Test User <test@example.com>

```
...and the most format-agnostic grep pattern I could think of was to find the first occurrence of groups of hexadecimal numbers and spaces, and then truncate the result.