### PR TITLE
Disable Screensaver

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,10 @@
                 # Comment out to run in a console for a smaller iso and less RAM.
                 xserver = {
                   enable = true;
-                  desktopManager.xfce.enable = true;
+                  desktopManager.xfce = {
+                    enable = true;
+                    enableScreensaver = false;
+                  };
                   displayManager = {
                     lightdm.enable = true;
                     autoLogin = {


### PR DESCRIPTION
Currently, the screensaver is enabled. This causes the session to lock after a certain amount of time.
With autologin enabled and the user having no default password, this means that the session cannot be unlocked again.

Thus, changes made in this PR disable the screensaver.