### PR TITLE
Add the `diceware` Web-App to the NixOS ISO

### DIFF
--- a/diceware-vt.patch
+++ b/diceware-vt.patch
@@ -1,0 +1,65 @@
+diff --git a/index.html b/index.html
+index 2f26ed9..3b4a2d3 100644
+--- a/index.html
++++ b/index.html
+@@ -920,8 +920,19 @@
+     <!-- core application JS -->
+     <script
+       src="index.js"
+-      integrity="sha384-++jBnvz86d0OUZ3chFxES5Sj6jjOZ/jKegsrHhXhOEzWxrvn7LhRGB0HP+bvLeNI"
++      integrity="sha384-v759g0TMj/jSFxhXsmlahbhJnj5NYNBopqVDq9WQaMOWsLZ0sJzLKxIoP+WzY9Yq"
+       crossorigin="anonymous"
+     ></script>
++    <script>
++      $(document).ready(function () {
++        'use strict'
++        // Use the 6 word list as the default
++        var numWords, numRolls
++        numWords = parseInt(6, 10)
++        numRolls = parseInt(5, 10)
++        displayWords(getWords(numWords, numRolls))
++        displayCrackTime(wordList)
++      })
++    </script>
+   </body>
+ </html>
+diff --git a/index.js b/index.js
+index e95e2a1..9d45377 100644
+--- a/index.js
++++ b/index.js
+@@ -238,11 +238,28 @@ function getWordFromWordNum (wordNum) {
+ function displayWords (words) {
+   'use strict'
+ 
++  // get symbol and number for the first and third words (CMD)
++  if (words.length > 1) {
++	  var symbols = getWords(1,2)
++	  var number = Math.floor(Math.random() * 100)
++	  var symbol_pos = Math.floor(Math.random() * words.length)
++	  var number_pos = Math.floor(Math.random() * words.length)
++	  var capitalize_pos = Math.floor(Math.random() * words.length)
++  }
++
+   // add the word to the global array of words
+   $.each(words, function (index, obj) {
+     var objEntropy = new Big(obj.entropy)
+     totalEntropy = totalEntropy.plus(objEntropy)
+     $('#totalEntropy').text(totalEntropy.toFixed(2))
++    if (words.length > 1) {
++      // add symbol to random word (CMD)
++      if (index == symbol_pos) obj.word = obj.word + symbols[0].word
++      // add number to random word (CMD)
++      if (index == number_pos) obj.word = obj.word + number
++      // capitalize random word (CMD)
++      if (index == capitalize_pos) obj.word = obj.word.charAt(0).toUpperCase() + obj.word.substring(1)
++    }
+     wordList.push(obj.word)
+   })
+ 
+@@ -370,4 +387,4 @@ $(document).ready(function () {
+     $('#addFiveDieRollWord').val('')
+     displayCrackTime(wordList)
+   })
+-})
++})
+\ No newline at end of file

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,8 @@
                 sed '/pinentry-program/d' ${drduhConfig}/gpg-agent.conf > $out
                 echo "pinentry-program ${pkgs.pinentry.curses}/bin/pinentry" >> $out
               '';
+              dicewareAddress = "localhost";
+              dicewarePort = 8080;
               viewYubikeyGuide = pkgs.writeShellScriptBin "view-yubikey-guide" ''
                 viewer="$(type -P xdg-open || true)"
                 if [ -z "$viewer" ]; then
@@ -48,6 +50,38 @@
               yubikeyGuide = pkgs.symlinkJoin {
                 name = "yubikey-guide";
                 paths = [viewYubikeyGuide shortcut];
+              };
+              dicewareScript = pkgs.writeShellScriptBin "diceware-webapp" ''
+                viewer="$(type -P xdg-open || true)"
+                if [ -z "$viewer" ]; then
+                  viewer="firefox"
+                fi
+                exec $viewer "http://"${lib.escapeShellArg dicewareAddress}":${toString dicewarePort}/index.html"
+              '';
+              dicewarePage = pkgs.stdenv.mkDerivation {
+                name = "diceware-page";
+                src = pkgs.fetchFromGitHub {
+                  owner = "grempe";
+                  repo = "diceware";
+                  rev = "9ef886a2a9699f73ae414e35755fd2edd69983c8";
+                  sha256 = "44rpK8svPoKx/e/5aj0DpEfDbKuNjroKT4XUBpiOw2g=";
+                };
+                patches = [
+                  # Include changes published on https://secure.research.vt.edu/diceware/
+                  ./diceware-vt.patch
+                ];
+                buildPhase = ''
+                  cp -a . $out
+                '';
+              };
+              dicewareWebApp = pkgs.makeDesktopItem {
+                name = "diceware";
+                icon = "${dicewarePage}/favicon.ico";
+                desktopName = "Diceware Passphrase Generator";
+                genericName = "Passphrase Generator";
+                comment = "Open the passphrase generator in a web browser";
+                categories = ["Utility"];
+                exec = "${dicewareScript}/bin/${dicewareScript.name}";
               };
             in {
               isoImage = {
@@ -87,9 +121,34 @@
                     };
                   };
                 };
+                # Host the `https://secure.research.vt.edu/diceware/` website offline
+                nginx = {
+                  enable = true;
+                  virtualHosts."diceware.local" = {
+                    listen = [
+                        {
+                        addr = dicewareAddress;
+                        port = dicewarePort;
+                      }
+                    ];
+                    root = "${dicewarePage}";
+                  };
+                };
               };
 
               programs = {
+                # Add firefox for running the diceware web app
+                firefox = {
+                  enable = true;
+                  preferences = {
+                    # Disable data reporting confirmation dialogue
+                    "datareporting.policy.dataSubmissionEnabled" = false;
+                    # Disable welcome tab
+                    "browser.aboutwelcome.enabled" = false;
+                  };
+                  # Make preferences appear as user-defined values
+                  preferencesStatus = "user";
+                };
                 ssh.startAgent = false;
                 gnupg.agent = {
                   enable = true;
@@ -138,6 +197,7 @@
 
                 # Password generation tools
                 diceware
+                dicewareWebApp
                 pwgen
 
                 # Might be useful beyond the scope of the guide
@@ -194,6 +254,7 @@
 
                 cp -R ${self}/contrib/* ${homeDir}
                 ln -sf ${yubikeyGuide}/share/applications/yubikey-guide.desktop ${desktopDir}
+                ln -sf ${dicewareWebApp}/share/applications/${dicewareWebApp.name} ${desktopDir}
                 ln -sfT ${self} ${documentsDir}/YubiKey-Guide
               '';
               system.stateVersion = "23.11";


### PR DESCRIPTION
Although, the `diceware` CLI is included in the NixOS image, passphrases generated with it are slightly different from the page linked in the guide (https://secure.research.vt.edu/diceware/).

Changes made in this PR add the `grempe/diceware` project to the NixOS image and also patch it with the minor changes published on the `https://secure.research.vt.edu/diceware/` website to generate slightly different-looking passphrases (including numbers and symbols).