### PR TITLE
Add a Markdown Viewer to the NixOS Image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -149,6 +149,9 @@
                 # This guide itself (run `view-yubikey-guide` on the terminal
                 # to open it in a non-graphical environment).
                 yubikeyGuide
+
+                # PDF and Markdown viewer
+                okular
               ];
 
               # Disable networking so the system is air-gapped


### PR DESCRIPTION
Currently, when trying to open the guide, the corresponding markdown file is opened using Xfce's [Mousepad](https://docs.xfce.org/apps/mousepad/start) app which looks a little janky (considering it doesn't use a monospace font and doesn't do any syntax highlighting).

Changes made in this PR add `okular` to the NixOS image which is automatically associated to `text/markdown` files, effectively causing markdown files to be opened using `okular` by default.