### PR TITLE
Suggest Exporting the `GNUPGHOME` Variable in the Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ sudo dnf install \
 Create a temporary directory which will be cleared on [reboot](https://en.wikipedia.org/wiki/Tmpfs) and set it as the GnuPG directory:
 
 ```console
-GNUPGHOME=$(mktemp -d -t gnupg-$(date +%Y-%m-%d)-XXXXXXXXXX)
+export GNUPGHOME=$(mktemp -d -t gnupg-$(date +%Y-%m-%d)-XXXXXXXXXX)
 ```
 
 ## Configuration


### PR DESCRIPTION
This PR addresses issue #434.

When merely setting the `GNUPGHOME` variable without exporting it, subsequent `gpg` calls will silently ignore this variable and instead use `~/.gnupg` as home.

Changes made in this PR add the `export` command to the guide for preventing readers (such as myself)  to do the same error.

That's about everything I wanted to PR-spam!

Thank you so much for your great work, this really helps me a lot 😄 