### PR TITLE
Update flake.lock, system.stateVersion and migrate displayManager setting

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720110830,
-        "narHash": "sha256-E5dN9GDV4LwMEduhBLSkyEz51zM17XkWZ3/9luvNOPs=",
+        "lastModified": 1721226092,
+        "narHash": "sha256-UBvzVpo5sXSi2S/Av+t+Q+C2mhMIw/LBEZR+d6NMjws=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0d0be00d4ecc4b51d2d6948e37466194c1e6c51",
+        "rev": "c716603a63aca44f39bef1986c13402167450e0a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -266,7 +266,7 @@
                 ln -sf ${dicewareWebApp}/share/applications/${dicewareWebApp.name} ${desktopDir}
                 ln -sfT ${self} ${documentsDir}/YubiKey-Guide
               '';
-              system.stateVersion = "23.11";
+              system.stateVersion = "24.05";
             }
           )
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -118,10 +118,12 @@
                   };
                   displayManager = {
                     lightdm.enable = true;
-                    autoLogin = {
-                      enable = true;
-                      user = "nixos";
-                    };
+                  };
+                };
+                displayManager = {
+                  autoLogin = {
+                    enable = true;
+                    user = "nixos";
                   };
                 };
                 # Host the `https://secure.research.vt.edu/diceware/` website offline


### PR DESCRIPTION
Hi, I've updated flake.lock as per the README.md in this repository. I've noticed that the `stateVersion` variable was still set to 23.11. I suppose this is safe to change, since I don't expect anyone update their yubikey live usb.

While testing out the build, I've also noticed that a setting path was renamed (`autoLogin`), and I have adjusted the path accordingly.