### PR TITLE
docs(wsl): Add usbipd-win in WSL setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1389,6 +1389,26 @@ Connect to the remote host and use `ssh-add -l` to confirm forwarding works.
 
 Agent forwarding may be chained through multiple hosts. Follow the same [protocol](#remote-host-configuration) to configure each host.
 
+An alternate method is the [usbipd-win](https://github.com/dorssel/usbipd-win) library. If you encounter issues with accessing the YubiKey in WSL after configuring usbipd-win, you may need to add custom polkit rules to ensure proper permissions for the pcscd service. Here's an example configuration using a scard group (the group logic is optional):
+
+Create a new rule file at /etc/polkit-1/rules.d/99-pcscd.rules:
+
+```bash
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.debian.pcsc-lite.access_card" &&
+        subject.isInGroup("scard")) {
+        return polkit.Result.YES;
+    }
+});
+
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.debian.pcsc-lite.access_pcsc" &&
+        subject.isInGroup("scard")) {
+        return polkit.Result.YES;
+    }
+});
+```
+
 ### Replace agents
 
 To launch `gpg-agent` for use by SSH, use the `gpg-connect-agent /bye` or `gpgconf --launch gpg-agent` commands.


### PR DESCRIPTION
I recently moved away from the archived weasel-pageant and some other hacky options. I found that usbipd-win is a very nice solution. I ran into authentication issues on my PC so I included those in the docs. I am not sure if you want to include this in the README. Feel free to reject or change this PR. Just thought I would contribute back since this documentation helped me.  

PS: I set this up a while ago, but I believe all I had to do was setup usbipd-win according to their docs and then add the polkit rules, but maybe someone could verify.

