### PR TITLE
2025-06-18 gpg-agent.conf better default pinentry-program behaviour

### DIFF
--- a/config/gpg-agent.conf
+++ b/config/gpg-agent.conf
@@ -5,12 +5,26 @@ ttyname $GPG_TTY
 default-cache-ttl 60
 max-cache-ttl 120
 # Select a valid program path for PIN entry prompt
-pinentry-program /usr/bin/pinentry-curses
+# -- Linux (default /usr/bin/pinentry)
+#pinentry-program /usr/bin/pinentry
+#pinentry-program /usr/bin/pinentry-curses
 #pinentry-program /usr/bin/pinentry-gnome3
 #pinentry-program /usr/bin/pinentry-tty
 #pinentry-program /usr/bin/pinentry-x11
+# -- macOS - Intel silicon (default /usr/local/bin/pinentry)
+#pinentry-program /usr/local/bin/pinentry
 #pinentry-program /usr/local/bin/pinentry-curses
 #pinentry-program /usr/local/bin/pinentry-mac
+#pinentry-program /usr/local/bin/pinentry-tty
+# -- macOS - Apple silicon (default /opt/homebrew/bin/pinentry)
+#pinentry-program /opt/homebrew/bin/pinentry
+#pinentry-program /opt/homebrew/bin/pinentry-curses
 #pinentry-program /opt/homebrew/bin/pinentry-mac
+#pinentry-program /opt/homebrew/bin/pinentry-tty
+# -- macOS - MacPorts
+#pinentry-program /opt/local/bin/pinentry
+# -- macOS - MacGPG2
+#pinentry-program /usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac
+# -- Windows
 # https://developers.yubico.com/PGP/SSH_authentication/Windows.html
 #enable-win32-openssh-support


### PR DESCRIPTION
Adjusts the `gpg-agent.conf` template as follows:

1. Adds more `pinentry-program` variants likely to be found on current Linux and macOS systems.

2. Groups entries by OS and package.

3. Makes all `pinentry-program` directives inactive (commented-out).

At present, the `pinentry-program` directive active by default is:

```
pinentry-program /usr/bin/pinentry-curses
```

This works on Linux but fails on macOS.

However, if `gpg-agent.conf` either does not exist, or exists but does not contain **any** active `pinentry-program` directives, then my experimentation shows current OS releases behave as follows:

* Linux invokes:

	- `/usr/bin/pinentry-gnome3` (if a Desktop environment is available)
	- `/usr/bin/pinentry-curses` (otherwise)

	I have tested Debian, Ubuntu and Raspberry Pi OS.

* macOS invokes:

	- `/usr/local/bin/pinentry-curses` (Intel)
	- `/opt/homebrew/bin/pinentry-curses` (Apple)

	Those are true when `gnupg` has been installed by HomeBrew. I can't
	test either MacPorts or MacGPG2 directly but research suggests:

	- `/opt/local/bin/pinentry` (MacPorts)
	- `/usr/local/MacGPG2/libexec/pinentry-mac.app/Contents/MacOS/pinentry-mac` (MacGPG2)