### PR TITLE
fix: add missing macOS `brew` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,12 @@ sudo systemctl enable --now pcscd.service
 **macOS**
 
 ```console
+brew install gnupg
+```
+
+Or using MacPorts
+
+```console
 sudo port install gnupg2 pcsc-tools
 ```
 


### PR DESCRIPTION
that's the equivalent of the MacPorts command to the "Using YubiKey" section.