### PR TITLE
Fix command to upload key to `keys.openpgp.org`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1897,7 +1897,7 @@ gpg --keyserver hkps://keyserver.ubuntu.com:443 --send-key $KEYID
 Or if [uploading to keys.openpgp.org](https://keys.openpgp.org/about/usage):
 
 ```console
-gpg --send-key $KEYID | curl -T - https://keys.openpgp.org
+gpg --export $KEYID | curl -T - https://keys.openpgp.org
 ```
 
 The public key URL can also be added to YubiKey (based on [Shaw 2003](https://datatracker.ietf.org/doc/html/draft-shaw-openpgp-hkp-00)):


### PR DESCRIPTION
The current command for uploading keys to `keys.openpgp.org` is incorrect.

This PR fixes the command based on the usage instructions here (see screenshot below): https://keys.openpgp.org/about/usage/


<img width="918" height="252" alt="image" src="https://github.com/user-attachments/assets/9b40ff50-8642-4e75-bc75-c6a36e420799" />
