### PR TITLE
Nix flake update

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Build an air-gapped NixOS LiveCD image:
 ref=$(git ls-remote https://github.com/drduh/Yubikey-Guide refs/heads/master | awk '{print $1}')
 
 nix build --experimental-features "nix-command flakes" \
-    github:drduh/YubiKey-Guide/$ref#nixosConfigurations.yubikeyLive.x86_64-linux.config.system.build.isoImage
+    github:drduh/YubiKey-Guide/$ref?dir=nix#nixosConfigurations.yubikeyLive.x86_64-linux.config.system.build.isoImage
 ```
 
 If you have this repository checked out:
@@ -229,7 +229,7 @@ nix flake update --commit-lock-file
 Build the image:
 
 ```console
-nix build --experimental-features "nix-command flakes" .#nixosConfigurations.yubikeyLive.x86_64-linux.config.system.build.isoImage
+nix build --experimental-features "nix-command flakes" nix#nixosConfigurations.yubikeyLive.x86_64-linux.config.system.build.isoImage
 ```
 
 Copy to USB drive:

--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ sudo mkfs.ext2 /dev/mapper/gnupg-secrets -L gnupg-$(date +%F)
 Mount the filesystem and copy the temporary GnuPG working directory with key materials:
 
 ```console
-sudo mkdir /mnt/encrypted-storage
+sudo mkdir -p /mnt/encrypted-storage
 
 sudo mount /dev/mapper/gnupg-secrets /mnt/encrypted-storage
 
@@ -717,7 +717,7 @@ $ doas newfs sd3i
 Mount the filesystem and copy the temporary directory with the keyring:
 
 ```console
-doas mkdir /mnt/encrypted-storage
+doas mkdir -p /mnt/encrypted-storage
 
 doas mount /dev/sd3i /mnt/encrypted-storage
 
@@ -760,7 +760,7 @@ Create a filesystem and export the public key:
 ```console
 sudo mkfs.ext2 /dev/sdc2
 
-sudo mkdir /mnt/public
+sudo mkdir -p /mnt/public
 
 sudo mount /dev/sdc2 /mnt/public
 
@@ -794,7 +794,7 @@ Create a filesystem and export the public key to it:
 ```console
 doas newfs sd2b
 
-doas mkdir /mnt/public
+doas mkdir -p /mnt/public
 
 doas mount /dev/sd2b /mnt/public
 
@@ -1052,7 +1052,7 @@ Mount the non-encrypted volume with the public key:
 **Debian/Ubuntu**
 
 ```console
-sudo mkdir /mnt/public
+sudo mkdir -p /mnt/public
 
 sudo mount /dev/sdc2 /mnt/public
 ```
@@ -1060,7 +1060,7 @@ sudo mount /dev/sdc2 /mnt/public
 **OpenBSD**
 
 ```console
-doas mkdir /mnt/public
+doas mkdir -p /mnt/public
 
 doas mount /dev/sd3i /mnt/public
 ```
@@ -1938,7 +1938,7 @@ Decrypt and mount the encrypted volume:
 ```console
 sudo cryptsetup luksOpen /dev/sdc1 gnupg-secrets
 
-sudo mkdir /mnt/encrypted-storage
+sudo mkdir -p /mnt/encrypted-storage
 
 sudo mount /dev/mapper/gnupg-secrets /mnt/encrypted-storage
 ```
@@ -1946,7 +1946,7 @@ sudo mount /dev/mapper/gnupg-secrets /mnt/encrypted-storage
 Mount the non-encrypted public partition:
 
 ```console
-sudo mkdir /mnt/public
+sudo mkdir -p /mnt/public
 
 sudo mount /dev/sdc2 /mnt/public
 ```
@@ -2045,7 +2045,7 @@ sudo cryptsetup luksClose gnupg-secrets
 Export the updated public key:
 
 ```console
-sudo mkdir /mnt/public
+sudo mkdir -p /mnt/public
 
 sudo mount /dev/sdc2 /mnt/public
 

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,40 +1,23 @@
 {
   "nodes": {
-    "drduhConfig": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1719781410,
-        "narHash": "sha256-cmtAG7UQX7mVNoHHpVIqasfkjnO7VtBMcz8MJ7frO0k=",
-        "owner": "drduh",
-        "repo": "config",
-        "rev": "4eca229664d056737f1a097cdbdb10e5f247b0bc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "drduh",
-        "repo": "config",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721226092,
-        "narHash": "sha256-UBvzVpo5sXSi2S/Av+t+Q+C2mhMIw/LBEZR+d6NMjws=",
+        "lastModified": 1761468971,
+        "narHash": "sha256-vY2OLVg5ZTobdroQKQQSipSIkHlxOTrIF1fsMzPh8w8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c716603a63aca44f39bef1986c13402167450e0a",
+        "rev": "78e34d1667d32d8a0ffc3eba4591ff256e80576e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "drduhConfig": "drduhConfig",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -2,7 +2,7 @@
   description = "A Nix Flake for an xfce-based system with YubiKey setup";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
   };
 
   outputs = {
@@ -37,7 +37,7 @@
               '';
               shortcut = pkgs.makeDesktopItem {
                 name = "yubikey-guide";
-                icon = "${pkgs.yubikey-manager-qt}/share/icons/hicolor/128x128/apps/ykman.png";
+                icon = "${pkgs.yubioath-flutter}/share/icons/com.yubico.yubioath.png";
                 desktopName = "YubiKey Guide";
                 genericName = "Guide to using YubiKey for GnuPG and SSH";
                 comment = "Open YubiKey Guide in a reader program";
@@ -190,7 +190,6 @@
 
                 # Yubico's official tools
                 yubikey-manager
-                yubikey-manager-qt
                 yubikey-personalization
                 yubikey-personalization-gui
                 yubico-piv-tool
@@ -216,7 +215,7 @@
                 yubikeyGuide
 
                 # PDF and Markdown viewer
-                okular
+                kdePackages.okular
               ];
 
               # Disable networking so the system is air-gapped
@@ -265,7 +264,7 @@
                 ln -sf ${dicewareWebApp}/share/applications/${dicewareWebApp.name} ${desktopDir}
                 ln -sfT ${self} ${documentsDir}/YubiKey-Guide
               '';
-              system.stateVersion = "24.05";
+              system.stateVersion = "25.05";
             }
           )
         ];


### PR DESCRIPTION
- Update all `mkdir` commands to create parent directories if necessary
- Update `nix build` commands
- Update Nix flake to latest 25.05 (current stable)

Fixes some of https://github.com/drduh/YubiKey-Guide/issues/498