### PR TITLE
Add `gnupg2-scdaemon` as a required package for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,9 +268,9 @@ sudo yum install -y gnupg2 pinentry-curses pcsc-lite pcsc-lite-libs gnupg2-smime
 **Fedora**
 
 ```console
-sudo dnf install \
+sudo dnf install --skip-unavailable \
     wget gnupg2 \
-    cryptsetup pcsc-lite \
+    cryptsetup gnupg2-scdaemon pcsc-lite \
     yubikey-personalization-gui yubikey-manager
 ```
 


### PR DESCRIPTION
Since the release of Fedora 43, `gnupg2-scdaemon` has been split off from `gnupg2` into its own package. The `--skip-unavailable` flag for `dnf install` is added for backward compatibility with Fedora 42.