### PR TITLE
Set gpg login attribute as separate argument instead of $IDENTITY

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,13 +881,20 @@ ykman openpgp access set-retries 5 5 5 -f -a $ADMIN_PIN
 
 ## Set attributes
 
-Use previously set values:
+Set a public identifier for the gpg subsystem:
+```console
+export GPG_LOGIN_ATTR="My Cool YubiKey - 2025"
+```
+> [!IMPORTANT]
+> Anyone with access to the yubikey can see this attribute, even without authentication. It is recommended not to include personally identifiable information in this field to prevent a bad actor from associating a lost yubikey with its owner.
+
+Update the login attribute:
 
 ```console
 gpg --command-fd=0 --pinentry-mode=loopback --edit-card <<EOF
 admin
 login
-$IDENTITY
+$GPG_LOGIN_ATTR
 $ADMIN_PIN
 quit
 EOF

--- a/README.md
+++ b/README.md
@@ -893,7 +893,7 @@ quit
 EOF
 ```
 
-[Smart card attributes](https://gnupg.org/howtos/card-howto/en/smartcard-howto-single.html) can also be set with `gpg --edit-card` and `admin` mode. Use `help` to see available options. The `login` attribute is [required](https://github.com/drduh/YubiKey-Guide/issues/461).
+[Smart card attributes](https://gnupg.org/howtos/card-howto/en/smartcard-howto-single.html) can also be set with `gpg --edit-card` and `admin` mode. Use `help` to see available options. The [login](https://www.gnupg.org/documentation/manuals/gnupg/gpg_002dcard.html) attribute is [required](https://github.com/drduh/YubiKey-Guide/issues/461).
 
 Run `gpg --card-status` to verify results (*Login data* field).
 


### PR DESCRIPTION
Followup from https://github.com/drduh/YubiKey-Guide/issues/529

## ISSUE
### brief - the README instructs the user to populate a pgp attribute with possible PII without indicating that this field is public.

Suppose a user wants to generate subkeys for pgp encryption/decryption using subkeys and upload those public keys to a public repository. They set up their yubikey by running `export IDENTITY="YubiKey User <yubikey@example.domain>"` with their public email so it's easy to look up. This subkey will be different than the keys stored on the yubikey. After initial setup, the `$IDENTITY` field is not accessible from the card itself on an unauthorized system.

This guide [indicates](https://github.com/drduh/YubiKey-Guide?tab=readme-ov-file#set-attributes) that the user MUST set the login field in order to use subkeys. The problem is that the guide defaults this paramater to use `$IDENTITY`, which in this example contains the user's name and email address. This enables anybody with physical access to the card to pull the name and email of the individual. Below is the printout from `gpg --card-status` with my yubikey connected without any prior authentication through the pgp subsystem. This is using a live debian disk:
<img width="1175" height="849" alt="Screenshot_2026-05-15_21-41-06" src="https://github.com/user-attachments/assets/44faecc4-b262-4b21-8662-a3ab737cb116" />

The "Login data" field is displayed. (I set this to "N/A", but following the guide as it's written, this will display "YubiKey User <yubikey@example.domain>", or whatever name and email the user filled in. 

Unless I am mistaken, with no other context, this pgp parameter is the only PII attribute on the card thats accessible without any authentication. In the case that the key is lost, anyone who finds the key can identify the owner. This is an unneccessary security risk. Please let me know if i'm wrong or my understanding of the expectation of privacy using the pgp subsystem is incorrect.

## Changes
- Change the default value for the pgp login attribute to be "My Cool YubiKey - 2025"
- Add a disclaimer to the user regarding the described issue
- Add a hyperlink to the (very brief) explanation of the pgp login attribute
